### PR TITLE
fix: apply ignore_files filter unconditionally (fixes #7)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ ${config.figlet}
     // ignore any file that starts with a .git
     files = files.filter((file) => !file.startsWith('.git'));
   }
-  if (gitignoreExists && extraData.ignore_gitIgnoreFiles) {
+  if (extraData.ignore_files.length > 0) {
     console.log('\x1b[33m', 'Ignoring files: ', '\x1b[0m', extraData.ignore_files.toString());
     // filter out the files in the current directory that are in the ignore_files array
     files = files.filter((file) => !extraData.ignore_files.includes(file));


### PR DESCRIPTION
## What

The \`ignore_files\` filter in \`src/index.js\` was nested inside the
\`gitignoreExists && extraData.ignore_gitIgnoreFiles\` block, so it
silently no-op'd whenever the project had no \`.gitignore\` or the user
disabled \`ignore_gitIgnoreFiles\`. Entries listed in
\`awesome-readme.config.js\` under \`ignore_files\` then leaked into the
generated README's \`## Directories\` section and the directory tree.

## Fix

Decouple the two filters:
- \`.gitignore\` honoring stays gated on \`ignore_gitIgnoreFiles\` —
  it's about consuming the \`.gitignore\` file.
- \`ignore_files\` runs whenever the user has configured any entries.

## Repro / verification

Without the fix, in a fixture with no \`.gitignore\` and
\`ignore_gitIgnoreFiles: false\`, both \`.vscode/\` and
\`secret-folder/\` (listed in \`ignore_files\`) appeared in the
generated README.

After the fix, both are correctly excluded from \`## Directories\` and
the tree.

The original happy path (\`.gitignore\` present, \`ignore_gitIgnoreFiles:
true\`) still works — the project's own \`.prettierignore\` remains
filtered out of its generated README.

## Scope

Top-level \`src/index.js\` only. The same pattern does not apply inside
\`buildReadme.js\` — that function never applied \`ignore_files\` at all,
which is a separate concern from the bug reported in #7.

Fixes #7