### PR TITLE
fix: nest subdirectory contents under each directory in the tree

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,11 +83,13 @@ ${config.figlet}
   }
   const directory = [];
   const currentFiles = [];
+  // Map each subdirectory name to its rendered tree text so it can be nested
+  // under that directory in the parent tree instead of being dumped at the bottom.
+  const subDirectoryTreeMap = {};
 
   let directoryFileList = '';
   let currentFilesList = '';
   let directoryTree = `\`\`\`\n` + repositoryName + '/\n';
-  let subDirectoryTree = [];
 
   // identify if the files are directories or files
   files.map((file) => {
@@ -107,7 +109,7 @@ ${config.figlet}
         '   ',
         extraData
       );
-      subDirectoryTree += addToTree;
+      subDirectoryTreeMap[file] = addToTree;
       let subDirectoryFiles = fs.readdirSync(filePath + '/');
       if (subDirectoryFiles.length > 0)
         subDirectoryFiles.map((subDirectoryFile) => {
@@ -136,10 +138,25 @@ ${config.figlet}
   currentFiles.forEach((element) => {
     directoryTree += `│   ${element}\n`;
   });
-  directory.forEach((element) => {
-    directoryTree += `└─── ${element}/\n`;
+  directory.forEach((element, index) => {
+    const isLast = index === directory.length - 1;
+    const connector = isLast ? '└───' : '├───';
+    // Children of a non-last directory are drawn with a `│` so the parent's
+    // connector column continues; children of the last directory use blanks.
+    const childIndent = isLast ? '    ' : '│   ';
+    directoryTree += `${connector} ${element}/\n`;
+    // Nest the subdirectory's tree immediately under its directory entry so
+    // files from different subdirectories are no longer mixed at the bottom.
+    const subTree = subDirectoryTreeMap[element] || '';
+    subTree.split('\n').forEach((line) => {
+      if (line === '') return;
+      // buildReadme prefixes each of its lines with three spaces so that the
+      // subdirectory's tree lines up one level deep. Replace that prefix with
+      // the parent's child indent so the lines sit under the right connector.
+      directoryTree += `${childIndent}${line.replace(/^ {3}/, '')}\n`;
+    });
   });
-  directoryTree += subDirectoryTree + `\`\`\``;
+  directoryTree += `\`\`\``;
   const buildReadmeData = `
 [![license](https://img.shields.io/github/license/jamesisaac/react-native-background-task.svg)](https://opensource.org/licenses/${repositoryLicensee})
 ${extraData.root_license}


### PR DESCRIPTION
Closes #6.

## Problem

When the root README rendered its directory tree, every subdirectory's
rendered tree was appended to the bottom of the parent tree, so files
from different subdirectories ended up mixed together under the last
directory entry:

```
test-repo/
│   package.json
│   root.txt
└─── src/
└─── tests/
   │   a.js
   │   b.js
   │   c.js
   │   d.js
```

All directory entries also used the \`└───\` connector regardless of
position, which misrepresented the tree shape.

## Fix

Map each subdirectory to its rendered tree text in \`src/index.js\` and
emit it directly under that directory entry, using \`├───\` for non-last
entries and \`└───\` for the last one so the connector column
continues correctly:

```
test-repo/
│   package.json
│   root.txt
├─── src/
│   │   a.js
│   │   b.js
└─── tests/
    │   c.js
    │   d.js
```

## Verification

- Reproduced the bug on a test repo with two subdirectories each
  containing files; confirmed the fix produces the expected nested
  output.
- Verified deeper nesting (a subdirectory of a subdirectory) renders
  correctly.
- Verified the no-subdirectory case still renders correctly.
- \`npm run lint\`, \`npm run format:check\`, and \`npm run build\`
  all pass.