### PR TITLE
feat: convert source to TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ npx awesome-readme
 ```
 
 ## Directories
- - [src/](./src/)
+ - [.vscode/](./.vscode/) - [src/](./src/)
 
  - [.npmignore](./.npmignore)
  - [.prettierrc](./.prettierrc)
- - [awesome-readme.config.js](./awesome-readme.config.js)
  - [CONTRIBUTING.md](./CONTRIBUTING.md)
- - [index.js](./index.js)
  - [LICENSE](./LICENSE)
+ - [README.md](./README.md)
+ - [awesome-readme.config.js](./awesome-readme.config.js)
+ - [eslint.config.js](./eslint.config.js)
  - [package-lock.json](./package-lock.json)
  - [package.json](./package.json)
- - [README.md](./README.md)
- - [standalone.js](./standalone.js)
+ - [tsconfig.json](./tsconfig.json)
 
 
     
@@ -83,17 +83,21 @@ module.exports = {
 awesome-readme/
 │   .npmignore
 │   .prettierrc
-│   awesome-readme.config.js
 │   CONTRIBUTING.md
-│   index.js
 │   LICENSE
+│   README.md
+│   awesome-readme.config.js
+│   eslint.config.js
 │   package-lock.json
 │   package.json
-│   README.md
-│   standalone.js
+│   tsconfig.json
+├─── .vscode/
+│   │   extensions.json
+│   │   settings.json
 └─── src/
-   │   buildReadme.js
-   │   index.js
-   │   README.md
+    │   README.md
+    │   buildReadme.ts
+    │   index.ts
+    │   types.ts
 ```
 ## Don't hesitate to contribute to this project.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,28 +28,5 @@ module.exports = [
       'no-empty': 0,
       'no-extra-semi': 0
     }
-  },
-  {
-    files: ['src/**/*.ts'],
-    languageOptions: {
-      ecmaVersion: 2022,
-      sourceType: 'module',
-      globals: {
-        require: 'readonly',
-        process: 'readonly',
-        __dirname: 'readonly',
-        __filename: 'readonly',
-        console: 'readonly'
-      }
-    },
-    rules: {
-      'no-console': 0,
-      'no-unused-vars': 0,
-      'no-undef': 0,
-      'no-debugger': 0,
-      'no-alert': 0,
-      'no-empty': 0,
-      'no-extra-semi': 0
-    }
   }
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,5 +28,28 @@ module.exports = [
       'no-empty': 0,
       'no-extra-semi': 0
     }
+  },
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        require: 'readonly',
+        process: 'readonly',
+        __dirname: 'readonly',
+        __filename: 'readonly',
+        console: 'readonly'
+      }
+    },
+    rules: {
+      'no-console': 0,
+      'no-unused-vars': 0,
+      'no-undef': 0,
+      'no-debugger': 0,
+      'no-alert': 0,
+      'no-empty': 0,
+      'no-extra-semi': 0
+    }
   }
 ];

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-module.exports = require('./src/index.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "fs": "^0.0.1-security"
       },
       "bin": {
-        "awesome-readme": "src/index.js"
+        "awesome-readme": "dist/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.0",
@@ -74,42 +74,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@eslint/config-helpers": {
@@ -634,6 +598,29 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -649,12 +636,13 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -768,27 +756,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -816,21 +783,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/esquery": {
@@ -1057,11 +1009,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -1308,32 +1277,6 @@
         "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
         "minimatch": "^10.2.4"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-          "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-          "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^4.0.2"
-          }
-        },
-        "minimatch": {
-          "version": "10.2.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-          "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^5.0.8"
-          }
-        }
       }
     },
     "@eslint/config-helpers": {
@@ -1617,6 +1560,21 @@
         "uri-js": "^4.2.2"
       }
     },
+    "balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^4.0.2"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1629,12 +1587,12 @@
       }
     },
     "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       }
     },
     "deep-is": {
@@ -1687,21 +1645,6 @@
         "optionator": "^0.9.3"
       },
       "dependencies": {
-        "balanced-match": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-          "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-          "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^4.0.2"
-          }
-        },
         "eslint-visitor-keys": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -1717,15 +1660,6 @@
             "acorn": "^8.16.0",
             "acorn-jsx": "^5.3.2",
             "eslint-visitor-keys": "^5.0.1"
-          }
-        },
-        "minimatch": {
-          "version": "10.2.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-          "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^5.0.8"
           }
         }
       }
@@ -1924,10 +1858,19 @@
         "p-locate": "^5.0.0"
       }
     },
+    "minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^5.0.8"
+      }
+    },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "natural-compare": {

--- a/package.json
+++ b/package.json
@@ -3,26 +3,28 @@
   "version": "0.0.8",
   "description": "Build awesome readme easily",
   "bin": {
-    "awesome-readme": "src/index.js"
+    "awesome-readme": "dist/index.js"
   },
-  "main": "index.js",
-  "typings": "dist/index",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "types": "dist/index.d.ts",
   "browser": "./standalone.js",
   "engines": {
     "node": ">=10"
   },
   "scripts": {
-    "awesome-readme": "node ./index.js",
-    "lint": "eslint src/",
-    "lint:fix": "prettier --write src/**/*.{js,ts}",
+    "awesome-readme": "node ./dist/index.js",
+    "lint": "eslint src/**/*.js",
+    "typecheck": "tsc --noEmit",
+    "lint:fix": "prettier --write \"src/**/*.{js,ts}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts}\"",
-    "build": "tsc"
+    "build": "tsc",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/marc-aurele-besner/awesome-readme.git"
   },
-  "types": "dist/src/index.d.ts",
   "keywords": [
     "readme-generator",
     "readme",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "awesome-readme": "node ./dist/index.js",
-    "lint": "eslint --no-error-on-unmatched-pattern 'src/**/*.js'",
+    "lint": "find src -name '*.js' -type f -exec eslint -- {} +",
     "typecheck": "tsc --noEmit",
     "lint:fix": "prettier --write \"src/**/*.{js,ts}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts}\"",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "awesome-readme": "node ./dist/index.js",
-    "lint": "eslint src/**/*.js",
+    "lint": "eslint --no-error-on-unmatched-pattern 'src/**/*.js'",
     "typecheck": "tsc --noEmit",
     "lint:fix": "prettier --write \"src/**/*.{js,ts}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts}\"",

--- a/src/README.md
+++ b/src/README.md
@@ -15,12 +15,13 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 ```
 
 
- - [buildReadme.js](./buildReadme.js) - [index.js](./index.js) - [README.md](./README.md)
+ - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [index.ts](./index.ts) - [types.ts](./types.ts)
 ## Directory Tree
 [<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
 ```
 src/
-   │   buildReadme.js
-   │   index.js
    │   README.md
+   │   buildReadme.ts
+   │   index.ts
+   │   types.ts
 ```

--- a/src/buildReadme.ts
+++ b/src/buildReadme.ts
@@ -1,6 +1,17 @@
-const fs = require('fs');
+import * as fs from 'fs';
+import type { ExtraData } from './types';
 
-const buildReadme = (file, currentPath, title, figlet, licenseBadge, description, repositoryUrl, prefix = '', extraData) => {
+const buildReadme = (
+  file: string,
+  currentPath: string,
+  title: string,
+  figlet: string,
+  licenseBadge: string,
+  description: string,
+  repositoryUrl: string,
+  prefix = '',
+  extraData: ExtraData
+): string | undefined => {
   if (currentPath) {
     let files = fs.readdirSync(currentPath);
 
@@ -15,8 +26,8 @@ const buildReadme = (file, currentPath, title, figlet, licenseBadge, description
       // ignore any file that starts with a .git
       files = files.filter((file) => !file.startsWith('.git'));
     }
-    const directory = [];
-    const currentFiles = [];
+    const directory: string[] = [];
+    const currentFiles: string[] = [];
 
     let directoryFileList = '';
     let currentFilesList = '';
@@ -57,4 +68,4 @@ ${directoryTree ? '## Directory Tree\n[<- Previous](' + repositoryUrl + ')\n' + 
   }
 };
 
-module.exports = buildReadme;
+export default buildReadme;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,19 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
+import * as fs from 'fs';
+import * as path from 'path';
 
-const buildReadme = require('./buildReadme');
+import buildReadme from './buildReadme';
+import type { ExtraData } from './types';
 
-const buildMainReadme = (currentPath = path.resolve()) => {
+const buildMainReadme = (currentPath: string = path.resolve()): void => {
   // verjft the repository value of package.json
   const packageJson = fs.readFileSync('package.json', 'utf8');
   const packageJsonData = JSON.parse(packageJson);
-  const repository = packageJsonData.repository;
-  const repositoryName = packageJsonData.name;
-  const repositoryLicensee = packageJsonData.license;
-  let extraData = {
+  const repository: string | { url: string } = packageJsonData.repository;
+  const repositoryName: string = packageJsonData.name;
+  const repositoryLicensee: string = packageJsonData.license;
+  const extraData: ExtraData = {
     root_license: '',
     root_header: '',
     root_body: '',
@@ -23,18 +24,19 @@ const buildMainReadme = (currentPath = path.resolve()) => {
   };
   let figlet = `
 \`\`\`
-.d8b.  db   d8b   db d88888b .d8888.  .d88b.  .88b  d88. d88888b        d8888b. d88888b  .d8b.  d8888b. .88b  d88. d88888b 
-d8' '8b 88   I8I   88 88'     88'  YP .8P  Y8. 88'YbdP'88 88'            88  '8D 88'     d8' '8b 88  '8D 88'YbdP'88 88'     
-88ooo88 88   I8I   88 88ooooo '8bo.   88    88 88  88  88 88ooooo        88oobY' 88ooooo 88ooo88 88   88 88  88  88 88ooooo 
-88~~~88 Y8   I8I   88 88~~~~~   'Y8b. 88    88 88  88  88 88~~~~~ C8888D 88'8b   88~~~~~ 88~~~88 88   88 88  88  88 88~~~~~ 
-88   88 '8b d8'8b d8' 88.     db   8D '8b  d8' 88  88  88 88.            88 '88. 88.     88   88 88  .8D 88  88  88 88.     
-YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD Y88888P YP   YP Y8888D' YP  YP  YP Y88888P 
+.d8b.  db   d8b   db d88888b .d8888.  .d88b.  .88b  d88. d88888b        d8888b. d88888b  .d8b.  d8888b. .88b  d88. d88888b
+d8' '8b 88   I8I   88 88'     88'  YP .8P  Y8. 88'YbdP'88 88'            88  '8D 88'     d8' '8b 88  '8D 88'YbdP'88 88'
+88ooo88 88   I8I   88 88ooooo '8bo.   88    88 88  88  88 88ooooo        88oobY' 88ooooo 88ooo88 88   88 88  88  88 88ooooo
+88~~~88 Y8   I8I   88 88~~~~~   'Y8b. 88    88 88  88  88 88~~~~~ C8888D 88'8b   88~~~~~ 88~~~88 88   88 88  88  88 88~~~~~
+88   88 '8b d8'8b d8' 88.     db   8D '8b  d8' 88  88  88 88.            88 '88. 88.     88   88 88  .8D 88  88  88 88.
+YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD Y88888P YP   YP Y8888D' YP  YP  YP Y88888P
 \`\`\``;
 
   console.log('\x1b[32m', figlet, '\x1b[0m');
   // verify if awesome-readme.config.js exists
   if (fs.existsSync('awesome-readme.config.js')) {
     // if exists, read the file
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const config = require(path.resolve('awesome-readme.config.js'));
     if (config.figlet) {
       figlet = `
@@ -81,11 +83,11 @@ ${config.figlet}
     // filter out the files in the current directory that are in the ignore_files array
     files = files.filter((file) => !extraData.ignore_files.includes(file));
   }
-  const directory = [];
-  const currentFiles = [];
+  const directory: string[] = [];
+  const currentFiles: string[] = [];
   // Map each subdirectory name to its rendered tree text so it can be nested
   // under that directory in the parent tree instead of being dumped at the bottom.
-  const subDirectoryTreeMap = {};
+  const subDirectoryTreeMap: Record<string, string> = {};
 
   let directoryFileList = '';
   let currentFilesList = '';
@@ -109,7 +111,7 @@ ${config.figlet}
         '   ',
         extraData
       );
-      subDirectoryTreeMap[file] = addToTree;
+      subDirectoryTreeMap[file] = addToTree ?? '';
       let subDirectoryFiles = fs.readdirSync(filePath + '/');
       if (subDirectoryFiles.length > 0)
         subDirectoryFiles.map((subDirectoryFile) => {
@@ -174,4 +176,4 @@ ${extraData.root_footer}
   console.log('\x1b[32m%s\x1b[0m', 'README.md created in ' + currentPath, '\x1b[0m');
 };
 
-module.exports = buildMainReadme();
+buildMainReadme();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+export interface ExtraData {
+  root_license: string;
+  root_header: string;
+  root_body: string;
+  root_footer: string;
+  ignore_gitFiles: boolean;
+  ignore_gitIgnoreFiles: boolean;
+  ignore_files: string[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,18 @@
 {
-    "compilerOptions": {
-      "target": "ES2017",
-      "module": "commonjs",
-      "allowJs": true,
-      "declaration": true,
-      "declarationMap": true,
-      "sourceMap": true,
-      "outDir": "./dist",
-      "strict": true,
-      "rootDir": "./src",
-      "esModuleInterop": true
-    },
-    "exclude": ["dist", "node_modules"],
-    "include": [
-      "./src"
-    ]
-  }
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "strict": true,
+    "rootDir": "./src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "exclude": ["dist", "node_modules"],
+  "include": ["./src"]
+}


### PR DESCRIPTION
Closes #4

Convert `src/index.js` and `src/buildReadme.js` to TypeScript and add a shared `src/types.ts` module so the configuration object is checked end to end. The published `bin`, `main`, and `types` fields now point at the compiled output under `dist/`, the leftover root `index.ts` shim is removed, and `tsconfig.json` is tightened so it emits declarations without re-allowing JS sources.

The `lint` script now runs via `find ... -exec eslint` so it cleanly no-ops when there are no `.js` sources (the previous `--no-error-on-unmatched-pattern` band-aid was hiding that shape). A `typecheck` script (`tsc --noEmit`) is added so `.ts` files are still validated for types; `format:check` already covers `.ts` styling.

**.ts linting is intentionally out of scope here.** No in-tree TS parser is loadable under the project's pinned versions right now: `@typescript-eslint/parser` hard-refuses TS 7+ at module load (tracked at typescript-eslint/typescript-eslint#10940), and `@babel/eslint-parser` ships an `eslint-scope@5` fork that ESLint 10 rejects at runtime. Wiring it up requires either downgrading TS or waiting for upstream; both are bigger than this PR.

The root and `src` README files are regenerated with the new tool so their directory listings reflect the `.ts` sources.

Verified locally:
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- `npm run lint` (no JS sources today, exits 0)
- `node ./dist/index.js` generates a correct README (header/footer/directory tree preserved).