### PR TITLE
feat: add sub_license, sub_header, sub_body, sub_footer for sub-readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ module.exports = {
     ````,
     root_body: `## Configuration with awesome-readme.config.js`,
     root_footer: `## Don't hesitate to contribute to this project.`,
+    sub_license: `[![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)`,
+    sub_header: `## About this directory`,
+    sub_body: `This directory is part of the awesome-readme project.`,
+    sub_footer: `## Don't hesitate to contribute to this project.`,
     ignore_gitFiles: true,
     ignore_gitIgnoreFiles: true,
     ignore_files: ['.prettierignore']

--- a/awesome-readme.config.js
+++ b/awesome-readme.config.js
@@ -52,6 +52,10 @@ module.exports = {
     \`\`\`\`,
     root_body: \`## Configuration with awesome-readme.config.js\`,
     root_footer: \`## Don't hesitate to contribute to this project.\`,
+    sub_license: \`[![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)\`,
+    sub_header: \`## About this directory\`,
+    sub_body: \`This directory is part of the awesome-readme project.\`,
+    sub_footer: \`## Don't hesitate to contribute to this project.\`,
     ignore_gitFiles: true,
     ignore_gitIgnoreFiles: true,
     ignore_files: ['.prettierignore']
@@ -59,6 +63,10 @@ module.exports = {
 \`\`\`
 `,
   root_footer: `## Don't hesitate to contribute to this project.`,
+  sub_license: `[![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)`,
+  sub_header: `## About this directory`,
+  sub_body: `This directory is part of the awesome-readme project.`,
+  sub_footer: `## Don't hesitate to contribute to this project.`,
   ignore_gitFiles: true,
   ignore_gitIgnoreFiles: true,
   ignore_files: ['.prettierignore']

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-readme",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "description": "Build awesome readme easily",
   "bin": {
     "awesome-readme": "dist/index.js"

--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,7 @@
 
 [![license](https://img.shields.io/github/license/jamesisaac/react-native-background-task.svg)](https://opensource.org/licenses/MIT)
 
-
+[![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
 # awesome-readme / src
 
 ```
@@ -14,8 +14,10 @@ d8' '8b 88   I8I   88 88'     88'  YP .8P  Y8. 88'YbdP'88 88'            88  '8D
 YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD Y88888P YP   YP Y8888D' YP  YP  YP Y88888P 
 ```
 
+## About this directory
 
  - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [index.ts](./index.ts) - [types.ts](./types.ts)
+This directory is part of the awesome-readme project.
 ## Directory Tree
 [<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
 ```
@@ -25,3 +27,4 @@ src/
    │   index.ts
    │   types.ts
 ```
+## Don't hesitate to contribute to this project.

--- a/src/buildReadme.ts
+++ b/src/buildReadme.ts
@@ -54,13 +54,16 @@ const buildReadme = (
     const directoryTreePrefix = `\`\`\`\n${file}/\n`;
     const directoryTreeSuffix = `\`\`\``;
     const buildReadme = `
-${licenseBadge ? licenseBadge + '\n\n' : ''}
+${licenseBadge ? licenseBadge + '\n\n' : ''}${extraData.sub_license}
 # ${title ? title : 'Awesome-Readme'}
 ${figlet}
 ${description ? description : ''}
+${extraData.sub_header}
 ${directoryFileList ? '## Directories\n' + directoryFileList + '\n' : ''}
 ${currentFilesList ? currentFilesList : ''}
+${extraData.sub_body}
 ${directoryTree ? '## Directory Tree\n[<- Previous](' + repositoryUrl + ')\n' + directoryTreePrefix + directoryTree + directoryTreeSuffix : ''}
+${extraData.sub_footer}
 `;
     fs.writeFileSync(currentPath + '/README.md', buildReadme);
     console.log('\x1b[32m%s\x1b[0m', 'README.md created in ' + currentPath, '\x1b[0m');

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,10 @@ const buildMainReadme = (currentPath: string = path.resolve()): void => {
     root_header: '',
     root_body: '',
     root_footer: '',
+    sub_license: '',
+    sub_header: '',
+    sub_body: '',
+    sub_footer: '',
     ignore_gitFiles: true,
     ignore_gitIgnoreFiles: true,
     ignore_files: []
@@ -49,6 +53,10 @@ ${config.figlet}
     if (config.root_header) extraData.root_header = config.root_header;
     if (config.root_body) extraData.root_body = config.root_body;
     if (config.root_footer) extraData.root_footer = config.root_footer;
+    if (config.sub_license) extraData.sub_license = config.sub_license;
+    if (config.sub_header) extraData.sub_header = config.sub_header;
+    if (config.sub_body) extraData.sub_body = config.sub_body;
+    if (config.sub_footer) extraData.sub_footer = config.sub_footer;
     if (config.ignore_gitFiles !== undefined) extraData.ignore_gitFiles = config.ignore_gitFiles;
     if (config.ignore_gitIgnoreFiles !== undefined) extraData.ignore_gitIgnoreFiles = config.ignore_gitIgnoreFiles;
     if (config.ignore_files !== undefined && config.ignore_files.length > 0) extraData.ignore_files = config.ignore_files;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,10 @@ export interface ExtraData {
   root_header: string;
   root_body: string;
   root_footer: string;
+  sub_license: string;
+  sub_header: string;
+  sub_body: string;
+  sub_footer: string;
   ignore_gitFiles: boolean;
   ignore_gitIgnoreFiles: boolean;
   ignore_files: string[];


### PR DESCRIPTION
Closes #8

Sub-README files currently ignore the header, body, footer, and license
content in `ExtraData` — only the root README used those fields. This
adds matching `sub_*` counterparts so users can inject the same four
slots into every generated sub-README, mirroring the root configuration
shape.

## Changes
- `src/types.ts` — add `sub_license`, `sub_header`, `sub_body`, `sub_footer` to `ExtraData`.
- `src/index.ts` — initialize the new fields and read them from `awesome-readme.config.js`.
- `src/buildReadme.ts` — slot the new fields into the sub-README template (license under the badge, header before the directories list, body between files and tree, footer at the end).
- `awesome-readme.config.js` — show the new keys in both the live values and the documentation block embedded in `root_body`.
- `README.md`, `src/README.md` — regenerated with the new fields.
- `package.json` — bumped to `0.1.0`.