### PR TITLE
fix: apply ignore_files when generating subdirectory READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npx awesome-readme
 ```
 
 ## Directories
- - [.vscode/](./.vscode/) - [src/](./src/)
+ - [.vscode/](./.vscode/) - [src/](./src/) - [test/](./test/)
 
  - [.npmignore](./.npmignore)
  - [.prettierrc](./.prettierrc)
@@ -105,10 +105,14 @@ awesome-readme/
 │   │   README.md
 │   │   extensions.json
 │   │   settings.json
-└─── src/
+├─── src/
+│   │   README.md
+│   │   buildReadme.ts
+│   │   filterFiles.ts
+│   │   index.ts
+│   │   types.ts
+└─── test/
     │   README.md
-    │   buildReadme.ts
-    │   index.ts
-    │   types.ts
+    │   filterFiles.test.js
 ```
 ## Don't hesitate to contribute to this project.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint:fix": "prettier --write \"src/**/*.{js,ts}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts}\"",
     "build": "tsc",
+    "test": "npm run build && node --test test/",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/src/buildReadme.ts
+++ b/src/buildReadme.ts
@@ -1,4 +1,6 @@
 import * as fs from 'fs';
+
+import { listFilteredFiles } from './filterFiles';
 import type { ExtraData } from './types';
 
 const buildReadme = (
@@ -13,19 +15,9 @@ const buildReadme = (
   extraData: ExtraData
 ): string | undefined => {
   if (currentPath) {
-    let files = fs.readdirSync(currentPath);
-
-    // Detect if a .gitignore file exists
-    if (files.includes('.gitignore') && extraData.ignore_gitIgnoreFiles) {
-      // List the files and patterns in the .gitignore file
-      const gitignore = fs.readFileSync('.gitignore', 'utf8');
-      // filter out the files in the current directory that are in the .gitignore file
-      files = files.filter((file) => !gitignore.includes(file));
-    }
-    if (extraData.ignore_gitFiles) {
-      // ignore any file that starts with a .git
-      files = files.filter((file) => !file.startsWith('.git'));
-    }
+    // Shared with the root walk so `ignore_files`, `.git*` and `.gitignore`
+    // rules are applied consistently at every depth.
+    const files = listFilteredFiles(currentPath, extraData);
     const directory: string[] = [];
     const currentFiles: string[] = [];
 

--- a/src/filterFiles.ts
+++ b/src/filterFiles.ts
@@ -1,0 +1,58 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { ExtraData } from './types';
+
+/**
+ * Ignore rules shared by the root listing and every subdirectory listing.
+ *
+ * Both walks used to filter files independently, which meant `ignore_files`
+ * was only honoured at the root and a file ignored there could still show up
+ * in a sub-README or subdirectory tree. Everything that lists files now goes
+ * through this module so the rules stay in sync.
+ */
+export interface FilterOptions {
+  ignore_gitFiles: boolean;
+  ignore_gitIgnoreFiles: boolean;
+  ignore_files: string[];
+}
+
+/**
+ * Apply the ignore rules to an already-read list of entry names.
+ *
+ * `gitignore` is the raw contents of the `.gitignore` that applies to the
+ * directory being scanned, or `undefined` when there is none. The matching is
+ * still a substring check against the raw contents, which is the pre-existing
+ * behaviour; proper gitignore pattern matching is tracked separately in #76.
+ */
+export const filterFiles = (files: string[], options: FilterOptions, gitignore?: string): string[] => {
+  let filtered = files;
+
+  if (gitignore !== undefined && options.ignore_gitIgnoreFiles) {
+    filtered = filtered.filter((file) => !gitignore.includes(file));
+  }
+  if (options.ignore_gitFiles) {
+    filtered = filtered.filter((file) => !file.startsWith('.git'));
+  }
+  if (options.ignore_files.length > 0) {
+    filtered = filtered.filter((file) => !options.ignore_files.includes(file));
+  }
+
+  return filtered;
+};
+
+/**
+ * Read a directory and return its entries with the ignore rules applied.
+ *
+ * The `.gitignore` used is the one living in the directory being scanned, so
+ * subdirectory walks no longer read the project root's file by mistake.
+ */
+export const listFilteredFiles = (currentPath: string, extraData: ExtraData): string[] => {
+  const files = fs.readdirSync(currentPath);
+  const gitignorePath = path.join(currentPath, '.gitignore');
+  const gitignore = files.includes('.gitignore') && fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, 'utf8') : undefined;
+
+  return filterFiles(files, extraData, gitignore);
+};
+
+export default listFilteredFiles;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import figletLib from 'figlet';
 
 import buildReadme from './buildReadme';
+import { listFilteredFiles } from './filterFiles';
 import type { ExtraData } from './types';
 
 const buildMainReadme = (currentPath: string = path.resolve()): void => {
@@ -106,28 +107,15 @@ ${rendered}
   const licenseBadge = repositorySlug
     ? `[![license](https://img.shields.io/github/license/${repositorySlug}.svg)](https://opensource.org/licenses/${repositoryLicensee})`
     : '';
-  // List of all the files in the current directory
-  let files = fs.readdirSync(currentPath);
-
-  // Detect if a .gitignore file exists
-  const gitignoreExists = files.includes('.gitignore');
-  if (gitignoreExists && extraData.ignore_gitIgnoreFiles) {
+  // List of all the files in the current directory, with the shared ignore
+  // rules applied. The same helper is used for every subdirectory walk so a
+  // file ignored here cannot reappear in a sub-README or subdirectory tree.
+  if (extraData.ignore_gitIgnoreFiles && fs.existsSync(path.join(currentPath, '.gitignore')))
     console.log('\x1b[33m', 'Using .gitignore to ignore files', '\x1b[0m');
-    // List the files and patterns in the .gitignore file
-    const gitignore = fs.readFileSync('.gitignore', 'utf8');
-    // filter out the files in the current directory that are in the .gitignore file
-    files = files.filter((file) => !gitignore.includes(file));
-  }
-  if (extraData.ignore_gitFiles) {
-    console.log('\x1b[33m', 'Ignoring .git files', '\x1b[0m');
-    // ignore any file that starts with a .git
-    files = files.filter((file) => !file.startsWith('.git'));
-  }
-  if (extraData.ignore_files.length > 0) {
-    console.log('\x1b[33m', 'Ignoring files: ', '\x1b[0m', extraData.ignore_files.toString());
-    // filter out the files in the current directory that are in the ignore_files array
-    files = files.filter((file) => !extraData.ignore_files.includes(file));
-  }
+  if (extraData.ignore_gitFiles) console.log('\x1b[33m', 'Ignoring .git files', '\x1b[0m');
+  if (extraData.ignore_files.length > 0) console.log('\x1b[33m', 'Ignoring files: ', '\x1b[0m', extraData.ignore_files.toString());
+
+  const files = listFilteredFiles(currentPath, extraData);
   const directory: string[] = [];
   const currentFiles: string[] = [];
   // Map each subdirectory name to its rendered tree text so it can be nested
@@ -147,7 +135,9 @@ ${rendered}
       directoryFileList += ` - [${file}/](./${file}/)\r`;
       const addToTree = buildReadme(file, filePath + '/', repositoryName + ' / ' + file, figlet, licenseBadge, '', repositoryUrl, '   ', extraData);
       subDirectoryTreeMap[file] = addToTree ?? '';
-      let subDirectoryFiles = fs.readdirSync(filePath + '/');
+      // Second-level walk: filter here too, otherwise an ignored directory
+      // would still get a README generated for it.
+      const subDirectoryFiles = listFilteredFiles(filePath + '/', extraData);
       if (subDirectoryFiles.length > 0)
         subDirectoryFiles.map((subDirectoryFile) => {
           const subDirectoryPath = path.resolve(filePath + '/' + subDirectoryFile);

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / test
 
 ```
 
@@ -16,16 +16,13 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [types.ts](./types.ts)
+ - [README.md](./README.md) - [filterFiles.test.js](./filterFiles.test.js)
 This directory is part of the awesome-readme project.
 ## Directory Tree
 [<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
 ```
-src/
+test/
    │   README.md
-   │   buildReadme.ts
-   │   filterFiles.ts
-   │   index.ts
-   │   types.ts
+   │   filterFiles.test.js
 ```
 ## Don't hesitate to contribute to this project.

--- a/test/filterFiles.test.js
+++ b/test/filterFiles.test.js
@@ -1,0 +1,79 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const { filterFiles, listFilteredFiles } = require('../dist/filterFiles');
+
+const options = (overrides = {}) => ({
+  ignore_gitFiles: true,
+  ignore_gitIgnoreFiles: true,
+  ignore_files: [],
+  ...overrides
+});
+
+test('filterFiles removes entries listed in ignore_files', () => {
+  const files = ['index.ts', 'secret.txt', 'README.md'];
+
+  assert.deepStrictEqual(filterFiles(files, options({ ignore_files: ['secret.txt'] })), ['index.ts', 'README.md']);
+});
+
+test('filterFiles keeps everything when ignore_files is empty', () => {
+  const files = ['index.ts', 'README.md'];
+
+  assert.deepStrictEqual(filterFiles(files, options()), files);
+});
+
+test('filterFiles removes .git* entries only when ignore_gitFiles is on', () => {
+  const files = ['.gitignore', '.github', 'index.ts'];
+
+  assert.deepStrictEqual(filterFiles(files, options()), ['index.ts']);
+  assert.deepStrictEqual(filterFiles(files, options({ ignore_gitFiles: false })), files);
+});
+
+test('filterFiles honours .gitignore contents only when ignore_gitIgnoreFiles is on', () => {
+  const files = ['dist', 'src'];
+
+  assert.deepStrictEqual(filterFiles(files, options(), 'dist\n'), ['src']);
+  assert.deepStrictEqual(filterFiles(files, options({ ignore_gitIgnoreFiles: false }), 'dist\n'), files);
+});
+
+// Regression test for #77: `ignore_files` used to be applied to the root
+// listing only, so an ignored file still showed up in subdirectory listings
+// and trees.
+test('listFilteredFiles applies ignore_files inside a subdirectory', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-'));
+  const subDirectory = path.join(root, 'src');
+  fs.mkdirSync(subDirectory);
+  fs.writeFileSync(path.join(subDirectory, 'index.ts'), '');
+  fs.writeFileSync(path.join(subDirectory, '.prettierignore'), '');
+
+  try {
+    const files = listFilteredFiles(subDirectory, options({ ignore_files: ['.prettierignore'] }));
+
+    assert.deepStrictEqual(files, ['index.ts']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// The subdirectory walk used to read the project root's `.gitignore` instead
+// of the one belonging to the directory being scanned.
+test('listFilteredFiles reads the .gitignore of the directory being scanned', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-'));
+  const subDirectory = path.join(root, 'src');
+  fs.mkdirSync(subDirectory);
+  fs.writeFileSync(path.join(root, '.gitignore'), 'index.ts\n');
+  fs.writeFileSync(path.join(subDirectory, '.gitignore'), 'generated.ts\n');
+  fs.writeFileSync(path.join(subDirectory, 'index.ts'), '');
+  fs.writeFileSync(path.join(subDirectory, 'generated.ts'), '');
+
+  try {
+    const files = listFilteredFiles(subDirectory, options());
+
+    assert.deepStrictEqual(files, ['index.ts']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #77

## Summary

`ignore_files` from `awesome-readme.config.js` was applied only to the root listing in `src/index.ts`. The subdirectory walk in `src/buildReadme.ts` and the second-level walk in `src/index.ts` each re-implemented their own filtering and skipped `ignore_files` entirely, so a file ignored at the root still appeared in sub-README listings and subdirectory trees.

This extracts the ignore rules into a single `src/filterFiles.ts` helper and routes every place that lists files through it.

## Changes

- **`src/filterFiles.ts`** (new) — `filterFiles()` (pure, applies the `.gitignore` / `.git*` / `ignore_files` rules to a list of entries) and `listFilteredFiles()` (reads a directory and applies them).
- **`src/buildReadme.ts`** — uses the shared helper, so `ignore_files` is now honoured in subdirectory listings and trees.
- **`src/index.ts`** — root walk and the second-level walk both use the shared helper. Previously an ignored directory could still get a README generated for it.
- **`test/filterFiles.test.js`** (new) — regression coverage via Node's built-in test runner, plus a `npm test` script. No new dependency.

Also fixes a related bug this surfaced: the subdirectory walk read the **project root's** `.gitignore` (`fs.readFileSync('.gitignore')`, cwd-relative) instead of the one belonging to the directory being scanned.

## Out of scope

Gitignore matching keeps its existing substring behaviour — proper pattern matching is #76, and glob support for `ignore_files` is #87. This PR only makes the existing rules consistent across walks.

## Verification

Reproduced on a fixture project with `ignore_files: ['secret.txt']` and a `src/secret.txt`.

Before (built from `main`), `src/README.md` contained:

```
 - [index.ts](./index.ts) - [secret.txt](./secret.txt)
   │   secret.txt
```

After, `secret.txt` is absent from both the root and subdirectory READMEs:

```
 - [index.ts](./index.ts)

src/
   │   index.ts
```

`npm run typecheck`, `npm test` (6 passing), `npm run lint` and `npm run format:check` all pass.

## Acceptance criteria

- [x] `ignore_files` entries are excluded from root and sub-directory listings/trees
- [x] Behavior is covered by a regression test
