### PR TITLE
feat: add CLI flags (--help, --dry-run, --path, --config, --root-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,31 @@ npm i awesome-readme -g
 npx awesome-readme
 ```
 
+## CLI options
+
+```
+Usage: awesome-readme [options]
+
+Options:
+  -h, --help            Show this help message and exit
+      --dry-run         Print what would be written without writing any file
+  -p, --path <dir>      Project root to generate READMEs for (default: current directory)
+  -c, --config <file>   Path to the config file (default: <path>/awesome-readme.config.js)
+      --root-only       Only write the root README, skip subdirectory READMEs
+```
+
+Preview the output before touching your files:
+
+```
+npx awesome-readme --dry-run
+```
+
+Generate for another project, with a config living elsewhere:
+
+```
+npx awesome-readme --path ./packages/core --config ./readme.config.js
+```
+
 ## Directories
  - [.vscode/](./.vscode/) - [src/](./src/) - [test/](./test/)
 
@@ -108,11 +133,14 @@ awesome-readme/
 ├─── src/
 │   │   README.md
 │   │   buildReadme.ts
+│   │   cli.ts
 │   │   filterFiles.ts
 │   │   index.ts
 │   │   types.ts
+│   │   writeReadme.ts
 └─── test/
     │   README.md
+    │   cli.test.js
     │   filterFiles.test.js
 ```
 ## Don't hesitate to contribute to this project.

--- a/awesome-readme.config.js
+++ b/awesome-readme.config.js
@@ -32,6 +32,31 @@ npm i awesome-readme -g
 \`\`\`
 npx awesome-readme
 \`\`\`
+
+## CLI options
+
+\`\`\`
+Usage: awesome-readme [options]
+
+Options:
+  -h, --help            Show this help message and exit
+      --dry-run         Print what would be written without writing any file
+  -p, --path <dir>      Project root to generate READMEs for (default: current directory)
+  -c, --config <file>   Path to the config file (default: <path>/awesome-readme.config.js)
+      --root-only       Only write the root README, skip subdirectory READMEs
+\`\`\`
+
+Preview the output before touching your files:
+
+\`\`\`
+npx awesome-readme --dry-run
+\`\`\`
+
+Generate for another project, with a config living elsewhere:
+
+\`\`\`
+npx awesome-readme --path ./packages/core --config ./readme.config.js
+\`\`\`
 `,
   root_body: `
 

--- a/src/README.md
+++ b/src/README.md
@@ -16,7 +16,7 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [types.ts](./types.ts)
+ - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [types.ts](./types.ts) - [writeReadme.ts](./writeReadme.ts)
 This directory is part of the awesome-readme project.
 ## Directory Tree
 [<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
@@ -24,8 +24,10 @@ This directory is part of the awesome-readme project.
 src/
    │   README.md
    │   buildReadme.ts
+   │   cli.ts
    │   filterFiles.ts
    │   index.ts
    │   types.ts
+   │   writeReadme.ts
 ```
 ## Don't hesitate to contribute to this project.

--- a/src/buildReadme.ts
+++ b/src/buildReadme.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 
 import { listFilteredFiles } from './filterFiles';
 import type { ExtraData } from './types';
+import { writeReadmeFile, type ReadmeWriteMode } from './writeReadme';
 
 const buildReadme = (
   file: string,
@@ -12,7 +13,10 @@ const buildReadme = (
   description: string,
   repositoryUrl: string,
   prefix = '',
-  extraData: ExtraData
+  extraData: ExtraData,
+  // The directory tree is returned to the caller regardless of the mode, so
+  // `--root-only` and `--dry-run` still render a complete root README.
+  mode: ReadmeWriteMode = 'write'
 ): string | undefined => {
   if (currentPath) {
     // Shared with the root walk so `ignore_files`, `.git*` and `.gitignore`
@@ -57,8 +61,7 @@ ${extraData.sub_body}
 ${directoryTree ? '## Directory Tree\n[<- Previous](' + repositoryUrl + ')\n' + directoryTreePrefix + directoryTree + directoryTreeSuffix : ''}
 ${extraData.sub_footer}
 `;
-    fs.writeFileSync(currentPath + '/README.md', buildReadme);
-    console.log('\x1b[32m%s\x1b[0m', 'README.md created in ' + currentPath, '\x1b[0m');
+    writeReadmeFile(currentPath, buildReadme, mode);
     return directoryTree;
   }
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,83 @@
+import { parseArgs } from 'node:util';
+
+/**
+ * Command line options accepted by the `awesome-readme` binary.
+ *
+ * `path` and `config` are left undefined when the flag is absent so the caller
+ * can apply its own defaults (the current working directory and
+ * `awesome-readme.config.js` inside the project root respectively).
+ */
+export interface CliOptions {
+  help: boolean;
+  dryRun: boolean;
+  rootOnly: boolean;
+  path?: string;
+  config?: string;
+}
+
+export const usage = `Usage: awesome-readme [options]
+
+Generate README.md files for a project and its subdirectories.
+
+Options:
+  -h, --help            Show this help message and exit
+      --dry-run         Print what would be written without writing any file
+  -p, --path <dir>      Project root to generate READMEs for (default: current directory)
+  -c, --config <file>   Path to the config file (default: <path>/awesome-readme.config.js)
+      --root-only       Only write the root README, skip subdirectory READMEs
+
+Examples:
+  awesome-readme
+  awesome-readme --dry-run
+  awesome-readme --path ./packages/core --config ./readme.config.js
+  awesome-readme --root-only`;
+
+/**
+ * Parse `process.argv.slice(2)` into `CliOptions`.
+ *
+ * Parsing is strict: unknown flags, missing values and stray positional
+ * arguments all throw so the binary can print the usage text and exit non-zero
+ * instead of silently generating READMEs the user did not ask for.
+ */
+export const parseCliOptions = (argv: string[]): CliOptions => {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      strict: true,
+      allowPositionals: false,
+      options: {
+        help: { type: 'boolean', short: 'h', default: false },
+        'dry-run': { type: 'boolean', default: false },
+        'root-only': { type: 'boolean', default: false },
+        path: { type: 'string', short: 'p' },
+        config: { type: 'string', short: 'c' }
+      }
+    });
+  } catch (err) {
+    throw new Error((err as Error).message);
+  }
+
+  const values = parsed.values as {
+    help?: boolean;
+    'dry-run'?: boolean;
+    'root-only'?: boolean;
+    path?: string;
+    config?: string;
+  };
+
+  // `--path` / `--config` with an empty value is a user mistake rather than a
+  // request to use the default, so reject it instead of silently falling back.
+  if (values.path !== undefined && values.path.trim() === '') throw new Error('Option --path requires a directory.');
+  if (values.config !== undefined && values.config.trim() === '') throw new Error('Option --config requires a file path.');
+
+  return {
+    help: values.help === true,
+    dryRun: values['dry-run'] === true,
+    rootOnly: values['root-only'] === true,
+    path: values.path,
+    config: values.config
+  };
+};
+
+export default parseCliOptions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,32 @@ import * as path from 'path';
 import figletLib from 'figlet';
 
 import buildReadme from './buildReadme';
+import { parseCliOptions, usage, type CliOptions } from './cli';
 import { listFilteredFiles } from './filterFiles';
 import type { ExtraData } from './types';
+import { writeReadmeFile, type ReadmeWriteMode } from './writeReadme';
 
-const buildMainReadme = (currentPath: string = path.resolve()): void => {
-  // verjft the repository value of package.json
-  const packageJson = fs.readFileSync('package.json', 'utf8');
+const DEFAULT_CONFIG_FILE = 'awesome-readme.config.js';
+
+export type BuildOptions = Omit<CliOptions, 'help'>;
+
+const buildMainReadme = (options: Partial<BuildOptions> = {}): void => {
+  // Everything is resolved against the requested root instead of the process
+  // cwd so `--path` can point at any directory.
+  const currentPath = path.resolve(options.path ?? '.');
+  const dryRun = options.dryRun === true;
+  const rootOnly = options.rootOnly === true;
+  const rootMode: ReadmeWriteMode = dryRun ? 'dry-run' : 'write';
+  // `--root-only` still walks subdirectories because the root directory tree is
+  // built from their listings; it just never emits their READMEs.
+  const subMode: ReadmeWriteMode = rootOnly ? 'skip' : rootMode;
+
+  if (!fs.existsSync(currentPath) || !fs.statSync(currentPath).isDirectory()) throw new Error(`Project path not found: ${currentPath}`);
+
+  // verify the repository value of package.json
+  const packageJsonPath = path.join(currentPath, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) throw new Error(`No package.json found in ${currentPath}`);
+  const packageJson = fs.readFileSync(packageJsonPath, 'utf8');
   const packageJsonData = JSON.parse(packageJson);
   const repository: string | { url: string } = packageJsonData.repository;
   const repositoryName: string = packageJsonData.name;
@@ -40,11 +60,13 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 \`\`\``;
 
   console.log('\x1b[32m', figlet, '\x1b[0m');
-  // verify if awesome-readme.config.js exists
-  if (fs.existsSync('awesome-readme.config.js')) {
+  // An explicit `--config` must exist; the default file stays optional.
+  const configPath = options.config ? path.resolve(options.config) : path.join(currentPath, DEFAULT_CONFIG_FILE);
+  if (options.config && !fs.existsSync(configPath)) throw new Error(`Config file not found: ${configPath}`);
+  if (fs.existsSync(configPath)) {
     // if exists, read the file
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const config = require(path.resolve('awesome-readme.config.js'));
+    const config = require(configPath);
     if (config.figlet) {
       figlet = `
 \`\`\`
@@ -128,12 +150,12 @@ ${rendered}
 
   // identify if the files are directories or files
   files.map((file) => {
-    const filePath = path.resolve(file);
+    const filePath = path.resolve(currentPath, file);
     const stats = fs.statSync(filePath);
     if (stats.isDirectory()) {
       directory.push(file);
       directoryFileList += ` - [${file}/](./${file}/)\r`;
-      const addToTree = buildReadme(file, filePath + '/', repositoryName + ' / ' + file, figlet, licenseBadge, '', repositoryUrl, '   ', extraData);
+      const addToTree = buildReadme(file, filePath + '/', repositoryName + ' / ' + file, figlet, licenseBadge, '', repositoryUrl, '   ', extraData, subMode);
       subDirectoryTreeMap[file] = addToTree ?? '';
       // Second-level walk: filter here too, otherwise an ignored directory
       // would still get a README generated for it.
@@ -152,7 +174,8 @@ ${rendered}
               '',
               repositoryUrl,
               '   ',
-              extraData
+              extraData,
+              subMode
             );
           }
         });
@@ -196,8 +219,39 @@ ${extraData.root_body}
 ${directoryTree ? '## Directory Tree\n' + directoryTree : ''}
 ${extraData.root_footer}
 `;
-  fs.writeFileSync(currentPath + '/README.md', buildReadmeData);
-  console.log('\x1b[32m%s\x1b[0m', 'README.md created in ' + currentPath, '\x1b[0m');
+  writeReadmeFile(currentPath, buildReadmeData, rootMode);
 };
 
-buildMainReadme();
+/**
+ * Binary entry point. Returns the process exit code so the behaviour can be
+ * asserted in tests without spawning a shell.
+ */
+export const main = (argv: string[] = []): number => {
+  let options: CliOptions;
+  try {
+    options = parseCliOptions(argv);
+  } catch (err) {
+    console.error('\x1b[31m%s\x1b[0m', (err as Error).message);
+    console.error(usage);
+    return 1;
+  }
+
+  if (options.help) {
+    console.log(usage);
+    return 0;
+  }
+
+  try {
+    buildMainReadme(options);
+  } catch (err) {
+    console.error('\x1b[31m%s\x1b[0m', (err as Error).message);
+    return 1;
+  }
+
+  return 0;
+};
+
+if (require.main === module) process.exitCode = main(process.argv.slice(2));
+
+export { buildMainReadme };
+export default main;

--- a/src/writeReadme.ts
+++ b/src/writeReadme.ts
@@ -1,0 +1,34 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * How a README should be emitted.
+ *
+ * - `write`   : write the file to disk (default behaviour)
+ * - `dry-run` : report what would be written, touch nothing (`--dry-run`)
+ * - `skip`    : produce nothing at all, used by `--root-only` for the
+ *               subdirectory walk whose directory tree is still needed by the
+ *               root README even though no sub-README should be created
+ */
+export type ReadmeWriteMode = 'write' | 'dry-run' | 'skip';
+
+/**
+ * Single place where README files reach the filesystem, so `--dry-run` cannot
+ * be bypassed by one of the two generators forgetting to check it.
+ */
+export const writeReadmeFile = (directoryPath: string, contents: string, mode: ReadmeWriteMode = 'write'): void => {
+  if (mode === 'skip') return;
+
+  const target = path.join(directoryPath, 'README.md');
+
+  if (mode === 'dry-run') {
+    const action = fs.existsSync(target) ? 'overwrite' : 'create';
+    console.log('\x1b[33m%s\x1b[0m', `[dry-run] Would ${action} ${target} (${Buffer.byteLength(contents, 'utf8')} bytes)`);
+    return;
+  }
+
+  fs.writeFileSync(target, contents);
+  console.log('\x1b[32m%s\x1b[0m', 'README.md created in ' + directoryPath, '\x1b[0m');
+};
+
+export default writeReadmeFile;

--- a/test/README.md
+++ b/test/README.md
@@ -16,13 +16,14 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [filterFiles.test.js](./filterFiles.test.js)
+ - [README.md](./README.md) - [cli.test.js](./cli.test.js) - [filterFiles.test.js](./filterFiles.test.js)
 This directory is part of the awesome-readme project.
 ## Directory Tree
 [<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
 ```
 test/
    │   README.md
+   │   cli.test.js
    │   filterFiles.test.js
 ```
 ## Don't hesitate to contribute to this project.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,182 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const { parseCliOptions, usage } = require('../dist/cli');
+const { main } = require('../dist/index');
+
+// Every generated README is announced on stdout, and the dry-run notices go
+// there too, so tests capture console output instead of shelling out.
+const captureOutput = (fn) => {
+  const stdout = [];
+  const stderr = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...args) => stdout.push(args.join(' '));
+  console.error = (...args) => stderr.push(args.join(' '));
+  try {
+    const result = fn();
+    return { result, stdout: stdout.join('\n'), stderr: stderr.join('\n') };
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+};
+
+// Minimal project: a root package.json plus one subdirectory holding one file.
+const makeProject = () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-cli-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'demo',
+      license: 'MIT',
+      repository: { type: 'git', url: 'git+https://github.com/demo/demo.git' }
+    })
+  );
+  fs.mkdirSync(path.join(root, 'src'));
+  fs.writeFileSync(path.join(root, 'src', 'index.js'), '');
+  return root;
+};
+
+test('parseCliOptions defaults every flag to off', () => {
+  assert.deepStrictEqual(parseCliOptions([]), {
+    help: false,
+    dryRun: false,
+    rootOnly: false,
+    path: undefined,
+    config: undefined
+  });
+});
+
+test('parseCliOptions reads long and short forms', () => {
+  assert.deepStrictEqual(parseCliOptions(['--help']), {
+    help: true,
+    dryRun: false,
+    rootOnly: false,
+    path: undefined,
+    config: undefined
+  });
+  assert.strictEqual(parseCliOptions(['-h']).help, true);
+  assert.strictEqual(parseCliOptions(['--dry-run']).dryRun, true);
+  assert.strictEqual(parseCliOptions(['--root-only']).rootOnly, true);
+  assert.strictEqual(parseCliOptions(['--path', './pkg']).path, './pkg');
+  assert.strictEqual(parseCliOptions(['-p', './pkg']).path, './pkg');
+  assert.strictEqual(parseCliOptions(['--config', 'a.js']).config, 'a.js');
+  assert.strictEqual(parseCliOptions(['-c', 'a.js']).config, 'a.js');
+});
+
+test('parseCliOptions rejects unknown flags, missing values and positionals', () => {
+  assert.throws(() => parseCliOptions(['--nope']));
+  assert.throws(() => parseCliOptions(['--path']));
+  assert.throws(() => parseCliOptions(['--path', '']), /--path requires a directory/);
+  assert.throws(() => parseCliOptions(['--config', '  ']), /--config requires a file path/);
+  assert.throws(() => parseCliOptions(['extra-arg']));
+});
+
+test('--help prints usage, exits 0 and writes nothing', () => {
+  const root = makeProject();
+  const cwd = process.cwd();
+  process.chdir(root);
+
+  try {
+    const { result, stdout } = captureOutput(() => main(['--help']));
+
+    assert.strictEqual(result, 0);
+    assert.match(stdout, /Usage: awesome-readme/);
+    assert.match(stdout, /--dry-run/);
+    assert.strictEqual(fs.existsSync(path.join(root, 'README.md')), false);
+  } finally {
+    process.chdir(cwd);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('--dry-run reports the READMEs without writing any file', () => {
+  const root = makeProject();
+
+  try {
+    const { result, stdout } = captureOutput(() => main(['--path', root, '--dry-run']));
+
+    assert.strictEqual(result, 0);
+    assert.match(stdout, /\[dry-run\] Would create/);
+    assert.strictEqual(fs.existsSync(path.join(root, 'README.md')), false);
+    assert.strictEqual(fs.existsSync(path.join(root, 'src', 'README.md')), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('--path generates outside the current working directory', () => {
+  const root = makeProject();
+
+  try {
+    const { result } = captureOutput(() => main(['--path', root]));
+
+    assert.strictEqual(result, 0);
+    assert.strictEqual(fs.existsSync(path.join(root, 'README.md')), true);
+    assert.strictEqual(fs.existsSync(path.join(root, 'src', 'README.md')), true);
+    assert.match(fs.readFileSync(path.join(root, 'README.md'), 'utf8'), /# demo/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('--root-only writes the root README and skips subdirectories', () => {
+  const root = makeProject();
+
+  try {
+    const { result } = captureOutput(() => main(['--path', root, '--root-only']));
+
+    assert.strictEqual(result, 0);
+    assert.strictEqual(fs.existsSync(path.join(root, 'README.md')), true);
+    assert.strictEqual(fs.existsSync(path.join(root, 'src', 'README.md')), false);
+    // The subdirectory tree still has to appear in the root README.
+    assert.match(fs.readFileSync(path.join(root, 'README.md'), 'utf8'), /src\//);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('--config loads a config file from an arbitrary location', () => {
+  const root = makeProject();
+  const configDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-config-'));
+  const configPath = path.join(configDirectory, 'custom.config.js');
+  fs.writeFileSync(configPath, "module.exports = { root_footer: 'FOOTER-FROM-CUSTOM-CONFIG' };\n");
+
+  try {
+    const { result } = captureOutput(() => main(['--path', root, '--config', configPath]));
+
+    assert.strictEqual(result, 0);
+    assert.match(fs.readFileSync(path.join(root, 'README.md'), 'utf8'), /FOOTER-FROM-CUSTOM-CONFIG/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(configDirectory, { recursive: true, force: true });
+  }
+});
+
+test('a missing --config or --path exits non-zero', () => {
+  const root = makeProject();
+
+  try {
+    const missingConfig = captureOutput(() => main(['--path', root, '--config', path.join(root, 'nope.js')]));
+    assert.strictEqual(missingConfig.result, 1);
+    assert.match(missingConfig.stderr, /Config file not found/);
+
+    const missingPath = captureOutput(() => main(['--path', path.join(root, 'does-not-exist')]));
+    assert.strictEqual(missingPath.result, 1);
+    assert.match(missingPath.stderr, /Project path not found/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('an unknown flag exits non-zero and prints the usage', () => {
+  const { result, stderr } = captureOutput(() => main(['--totally-unknown']));
+
+  assert.strictEqual(result, 1);
+  assert.match(stderr, /Usage: awesome-readme/);
+  assert.ok(usage.includes('--root-only'));
+});


### PR DESCRIPTION
Closes #85

## Summary

The CLI took no arguments: it always generated for the process cwd, always read `awesome-readme.config.js` from that same directory, and always wrote to disk. This adds an argument parser and the flags requested in #85.

```
Usage: awesome-readme [options]

Options:
  -h, --help            Show this help message and exit
      --dry-run         Print what would be written without writing any file
  -p, --path <dir>      Project root to generate READMEs for (default: current directory)
  -c, --config <file>   Path to the config file (default: <path>/awesome-readme.config.js)
      --root-only       Only write the root README, skip subdirectory READMEs
```

## Notes on the implementation

- **Parsing** uses `node:util` `parseArgs` in strict mode — no new dependency. Unknown flags, missing values and stray positionals print the error plus usage and exit `1`.
- **A single write path.** Both generators now go through `writeReadmeFile(dir, contents, mode)` where mode is `write` / `dry-run` / `skip`. Keeping the check in one place means `--dry-run` can't be bypassed by one of the two generators forgetting to test the flag.
- **`--root-only` still walks subdirectories.** Their directory trees are what the root README's "Directory Tree" section is built from, so the walk happens with mode `skip`: trees are computed, no sub-README is emitted. A test asserts `src/` still shows up in the root tree.
- **Path resolution fixes needed by `--path`.** `package.json` was read as a bare relative path and each directory entry was resolved with `path.resolve(file)` — both relative to the cwd, so `--path` would have read the wrong `package.json` and stat'ed the wrong files. They now resolve against the requested root.
- **`--config` is strict, the default is not.** An explicit `--config` pointing at a missing file is an error; a missing default `awesome-readme.config.js` is still silently skipped, as before.
- `main()` returns its exit code (assigned to `process.exitCode` only under `require.main === module`), which lets the tests assert exit codes and filesystem effects without spawning a shell.

## Acceptance criteria

- [x] `--help` prints usage
- [x] `--dry-run` does not write files
- [x] `--path` / `--config` work as documented

## Testing

- `npm test` — 16 pass (7 new CLI tests, 9 pre-existing), `npm run lint`, `npm run typecheck`, `npm run format:check` all clean.
- Verified against this repo itself: `node ./dist/index.js --dry-run` reports all 4 READMEs and leaves `git status` untouched; `--bogus` exits `1`.