### PR TITLE
fix: parse .gitignore with real gitignore semantics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "figlet": "^1.11.4",
-        "fs": "^0.0.1-security"
+        "fs": "^0.0.1-security",
+        "ignore": "^5.3.2"
       },
       "bin": {
         "awesome-readme": "dist/index.js"
@@ -943,10 +944,10 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-      "dev": true,
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -1832,10 +1833,9 @@
       }
     },
     "ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-      "dev": true
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
     },
     "imurmurhash": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "homepage": "https://github.com/marc-aurele-besner/awesome-readme#readme",
   "dependencies": {
     "figlet": "^1.11.4",
-    "fs": "^0.0.1-security"
+    "fs": "^0.0.1-security",
+    "ignore": "^5.3.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",

--- a/src/filterFiles.ts
+++ b/src/filterFiles.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import ignoreLib from 'ignore';
+
 import type { ExtraData } from './types';
 
 /**
@@ -18,18 +20,54 @@ export interface FilterOptions {
 }
 
 /**
+ * Parse the raw contents of a `.gitignore` into an `ignore` instance.
+ *
+ * Blank lines and `#` comments are skipped so the patterns that reach the
+ * library are exactly the ones that would apply to a real `.gitignore`.
+ */
+const compileGitignore = (contents: string): ReturnType<typeof ignoreLib> => {
+  const patterns = contents
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'));
+
+  return ignoreLib().add(patterns);
+};
+
+/**
+ * Whether a single entry is ignored by the compiled `.gitignore` patterns.
+ *
+ * Directory-only patterns like `dist/` only fire when the entry is a directory
+ * and the path is supplied with a trailing slash, so the filter tests both
+ * forms rather than guessing what the user meant.
+ */
+const isIgnoredByGitignore = (name: string, isDirectory: boolean, ig: ReturnType<typeof ignoreLib>): boolean => {
+  if (isDirectory) return ig.ignores(`${name}/`) || ig.ignores(name);
+  return ig.ignores(name);
+};
+
+/**
  * Apply the ignore rules to an already-read list of entry names.
  *
  * `gitignore` is the raw contents of the `.gitignore` that applies to the
- * directory being scanned, or `undefined` when there is none. The matching is
- * still a substring check against the raw contents, which is the pre-existing
- * behaviour; proper gitignore pattern matching is tracked separately in #76.
+ * directory being scanned, or `undefined` when there is none. The match is
+ * delegated to the `ignore` package, so `.gitignore` patterns (`*`, `dist/`,
+ * negation, etc.) are honoured instead of being reduced to a substring check.
+ *
+ * Directory-only patterns still need to be matched against entry types, so
+ * callers that know whether each entry is a file or directory should prefer
+ * `listFilteredFiles`, which routes through `filterEntries` for the
+ * type-aware check.
  */
 export const filterFiles = (files: string[], options: FilterOptions, gitignore?: string): string[] => {
   let filtered = files;
+  const ig = gitignore !== undefined ? compileGitignore(gitignore) : undefined;
 
-  if (gitignore !== undefined && options.ignore_gitIgnoreFiles) {
-    filtered = filtered.filter((file) => !gitignore.includes(file));
+  if (ig !== undefined && options.ignore_gitIgnoreFiles) {
+    // Without a directory flag we fall back to the bare-name match, which
+    // covers the common patterns used in tests and keeps the public API
+    // backward compatible.
+    filtered = filtered.filter((file) => !ig.ignores(file));
   }
   if (options.ignore_gitFiles) {
     filtered = filtered.filter((file) => !file.startsWith('.git'));
@@ -42,17 +80,56 @@ export const filterFiles = (files: string[], options: FilterOptions, gitignore?:
 };
 
 /**
+ * Entry metadata passed to `filterEntries` so directory-only gitignore
+ * patterns can be matched against the actual file type.
+ */
+export interface FilterEntry {
+  name: string;
+  isDirectory: boolean;
+}
+
+/**
+ * Type-aware variant of `filterFiles`.
+ *
+ * Same rule set as `filterFiles`, but with directory information attached so
+ * `.gitignore` patterns that distinguish files from directories (the trailing
+ * slash form, e.g. `dist/`) are honoured. `listFilteredFiles` produces the
+ * entries, so the actual filesystem walk stays in one place.
+ */
+export const filterEntries = (entries: FilterEntry[], options: FilterOptions, gitignore?: string): string[] => {
+  let filtered = entries;
+  const ig = gitignore !== undefined ? compileGitignore(gitignore) : undefined;
+
+  if (ig !== undefined && options.ignore_gitIgnoreFiles) {
+    filtered = filtered.filter((entry) => !isIgnoredByGitignore(entry.name, entry.isDirectory, ig));
+  }
+  if (options.ignore_gitFiles) {
+    filtered = filtered.filter((entry) => !entry.name.startsWith('.git'));
+  }
+  if (options.ignore_files.length > 0) {
+    filtered = filtered.filter((entry) => !options.ignore_files.includes(entry.name));
+  }
+
+  return filtered.map((entry) => entry.name);
+};
+
+/**
  * Read a directory and return its entries with the ignore rules applied.
  *
  * The `.gitignore` used is the one living in the directory being scanned, so
- * subdirectory walks no longer read the project root's file by mistake.
+ * subdirectory walks no longer read the project root's file by mistake, and
+ * each entry is stat'd so directory-only patterns can be matched correctly.
  */
 export const listFilteredFiles = (currentPath: string, extraData: ExtraData): string[] => {
   const files = fs.readdirSync(currentPath);
   const gitignorePath = path.join(currentPath, '.gitignore');
   const gitignore = files.includes('.gitignore') && fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, 'utf8') : undefined;
+  const entries: FilterEntry[] = files.map((name) => {
+    const stats = fs.statSync(path.join(currentPath, name));
+    return { name, isDirectory: stats.isDirectory() };
+  });
 
-  return filterFiles(files, extraData, gitignore);
+  return filterEntries(entries, extraData, gitignore);
 };
 
 export default listFilteredFiles;

--- a/test/filterFiles.test.js
+++ b/test/filterFiles.test.js
@@ -4,7 +4,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { test } = require('node:test');
 
-const { filterFiles, listFilteredFiles } = require('../dist/filterFiles');
+const { filterFiles, filterEntries, listFilteredFiles } = require('../dist/filterFiles');
 
 const options = (overrides = {}) => ({
   ignore_gitFiles: true,
@@ -37,6 +37,51 @@ test('filterFiles honours .gitignore contents only when ignore_gitIgnoreFiles is
 
   assert.deepStrictEqual(filterFiles(files, options(), 'dist\n'), ['src']);
   assert.deepStrictEqual(filterFiles(files, options({ ignore_gitIgnoreFiles: false }), 'dist\n'), files);
+});
+
+// Proper gitignore matching: the previous substring check would skip a file
+// referenced only by a wildcard pattern, e.g. `*.log` never contained the
+// literal substring `app.log`.
+test('filterFiles honours gitignore glob patterns', () => {
+  const files = ['app.log', 'main.ts', 'debug.log'];
+
+  assert.deepStrictEqual(filterFiles(files, options(), '*.log\n'), ['main.ts']);
+});
+
+test('filterFiles ignores blank lines and comments inside .gitignore', () => {
+  const files = ['dist', 'src', 'keep.txt'];
+
+  const gitignore = ['# build output', '', 'dist', '   ', '# trailing comment'].join('\n');
+
+  assert.deepStrictEqual(filterFiles(files, options(), gitignore), ['src', 'keep.txt']);
+});
+
+test('filterFiles honours negation patterns in .gitignore', () => {
+  const files = ['dist', 'dist-keep.md'];
+
+  assert.deepStrictEqual(filterFiles(files, options(), 'dist*\n!dist-keep.md\n'), ['dist-keep.md']);
+});
+
+// `filterEntries` is the type-aware variant used by the directory walk so
+// patterns like `dist/` (directory-only) match the right entries.
+test('filterEntries ignores directories when a pattern ends with a slash', () => {
+  const entries = [
+    { name: 'dist', isDirectory: true },
+    { name: 'dist', isDirectory: false },
+    { name: 'src', isDirectory: true }
+  ];
+
+  assert.deepStrictEqual(filterEntries(entries, options(), 'dist/\n'), ['dist', 'src']);
+});
+
+test('filterEntries ignores files when a bare pattern matches a file', () => {
+  const entries = [
+    { name: 'dist', isDirectory: true },
+    { name: 'dist', isDirectory: false },
+    { name: 'src', isDirectory: true }
+  ];
+
+  assert.deepStrictEqual(filterEntries(entries, options(), 'dist\n'), ['src']);
 });
 
 // Regression test for #77: `ignore_files` used to be applied to the root
@@ -73,6 +118,44 @@ test('listFilteredFiles reads the .gitignore of the directory being scanned', ()
     const files = listFilteredFiles(subDirectory, options());
 
     assert.deepStrictEqual(files, ['index.ts']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// End-to-end coverage for #76: a directory listed in `.gitignore` with a
+// trailing slash should be filtered out of the listing, and a same-named file
+// should not be wrongly matched.
+test('listFilteredFiles honours directory-only gitignore patterns against the filesystem', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-'));
+  fs.writeFileSync(path.join(root, '.gitignore'), 'dist/\n');
+  fs.mkdirSync(path.join(root, 'dist'));
+  fs.writeFileSync(path.join(root, 'dist', 'bundle.js'), '');
+  fs.writeFileSync(path.join(root, 'README.md'), '');
+  // Sibling file whose name happens to match the directory pattern, so the
+  // filter has to distinguish directories from files.
+  fs.writeFileSync(path.join(root, 'dist.txt'), '');
+
+  try {
+    const files = listFilteredFiles(root, options());
+
+    assert.deepStrictEqual(files.sort(), ['README.md', 'dist.txt']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('listFilteredFiles honours gitignore glob patterns against the filesystem', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-'));
+  fs.writeFileSync(path.join(root, '.gitignore'), '*.log\n');
+  fs.writeFileSync(path.join(root, 'app.log'), '');
+  fs.writeFileSync(path.join(root, 'debug.log'), '');
+  fs.writeFileSync(path.join(root, 'README.md'), '');
+
+  try {
+    const files = listFilteredFiles(root, options());
+
+    assert.deepStrictEqual(files, ['README.md']);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #76

The previous `.gitignore` filter ran a substring check against the raw
file contents, so standard patterns like `*.log`, `dist/`, and
negation (`!dist-keep.md`) silently failed to match anything. This
replaces the substring check with the well-known `ignore` npm package,
which understands the full gitignore grammar.

## Changes

- Add `ignore` as a runtime dependency in `package.json` (it was
  already in the lockfile as a transitive dependency of ESLint).
- `src/filterFiles.ts`:
  - `filterFiles` keeps its string-only signature for backward
    compatibility and delegates gitignore matching to the `ignore`
    package.
  - A new `filterEntries` accepts a `{ name, isDirectory }` pair so
    directory-only patterns (`dist/`) match directories without
    misclassifying files of the same name (e.g. `dist.txt`).
  - `listFilteredFiles` stats each entry and routes through
    `filterEntries` so the directory-walk path is type-aware.
  - Blank lines and `#`-prefixed comments inside `.gitignore` are
    skipped before reaching the library.

## Tests

- `filterFiles` now honours glob patterns (`*.log`), negation
  (`!dist-keep.md`), and blank/comment lines.
- `filterEntries` exercises the directory-aware path for both
  `dist/` (directory-only) and `dist` (bare) patterns.
- End-to-end `listFilteredFiles` tests cover real `.gitignore` files
  with `dist/`, `dist.txt`, and `*.log` patterns against a
  temporary directory tree.

All 23 tests pass, including the two existing regression tests for
`ignore_files` propagation and per-directory `.gitignore` lookup.
`npm run typecheck`, `npm run lint`, and `npm run format:check`
also pass.