### PR TITLE
fix: clean up package metadata (drop fake fs dep, remove broken browser field, bump engines.node)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "figlet": "^1.11.4",
-        "fs": "^0.0.1-security",
         "ignore": "^5.3.2"
       },
       "bin": {
@@ -26,7 +25,7 @@
         "typescript": "^7.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -926,11 +925,6 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1817,11 +1811,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
-    },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "glob-parent": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,8 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "types": "dist/index.d.ts",
-  "browser": "./standalone.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "scripts": {
     "awesome-readme": "node ./dist/index.js",
@@ -45,7 +44,6 @@
   "homepage": "https://github.com/marc-aurele-besner/awesome-readme#readme",
   "dependencies": {
     "figlet": "^1.11.4",
-    "fs": "^0.0.1-security",
     "ignore": "^5.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR tightens three small package metadata issues in one go, since they're all closely related packaging cleanups.

**Changes**

- **Drop `"fs": "^0.0.1-security"` from `dependencies`** (closes #74). This is the npm security placeholder package, not Node's built-in `fs` module. The source already uses `import * as fs from 'fs'`, which resolves to Node's builtin — listing it in dependencies was misleading for consumers. `npm install` was re-run to remove the entry from `package-lock.json` as well.
- **Remove the `browser` field from `package.json`** (closes #78). It pointed at `./standalone.js`, which does not exist in the repo. This is a Node CLI, so the field had no useful meaning anyway.
- **Bump `engines.node` from `>=10` to `>=18`** (closes #83). Node 10 has been EOL for years and is incompatible with the project's ESLint 10 / TypeScript 7 toolchain. CI already runs Node 24; `>=18` matches the active LTS line.

**Verification**

- `npm run build` — passes
- `npm run typecheck` — passes
- `npm test` — 23/23 pass
- `npm run lint` — passes
- `npm run format:check` — passes
- `node ./dist/index.js --help` — CLI runs correctly
- `node -e "require('fs')"` — confirms Node's builtin `fs` is unaffected

**Notes**

I deliberately did not bundle the `files` field cleanup from #84 in this PR. Removing `src/` from the published tarball is a slightly different decision (it affects what consumers see on npm and probably wants its own review), so I'm leaving it for a follow-up.

Closes #74, closes #78, closes #83.