### PR TITLE
Align subdirectory tree connectors with root tree rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,31 +116,33 @@ module.exports = {
 ## Directory Tree
 ```
 awesome-readme/
-│   .npmignore
-│   .prettierrc
-│   CONTRIBUTING.md
-│   LICENSE
-│   README.md
-│   awesome-readme.config.js
-│   eslint.config.js
-│   package-lock.json
-│   package.json
-│   tsconfig.json
+├─── .npmignore
+├─── .prettierrc
+├─── CONTRIBUTING.md
+├─── LICENSE
+├─── README.md
+├─── awesome-readme.config.js
+├─── eslint.config.js
+├─── package-lock.json
+├─── package.json
+└─── tsconfig.json
 ├─── .vscode/
-│   │   README.md
-│   │   extensions.json
-│   │   settings.json
+│   ├─── README.md
+│   ├─── extensions.json
+│   └─── settings.json
 ├─── src/
-│   │   README.md
-│   │   buildReadme.ts
-│   │   cli.ts
-│   │   filterFiles.ts
-│   │   index.ts
-│   │   types.ts
-│   │   writeReadme.ts
+│   ├─── README.md
+│   ├─── buildReadme.ts
+│   ├─── cli.ts
+│   ├─── filterFiles.ts
+│   ├─── index.ts
+│   ├─── tree.ts
+│   ├─── types.ts
+│   └─── writeReadme.ts
 └─── test/
-    │   README.md
-    │   cli.test.js
-    │   filterFiles.test.js
+    ├─── README.md
+    ├─── cli.test.js
+    ├─── filterFiles.test.js
+    └─── tree.test.js
 ```
 ## Don't hesitate to contribute to this project.

--- a/src/README.md
+++ b/src/README.md
@@ -16,18 +16,19 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [types.ts](./types.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [writeReadme.ts](./writeReadme.ts)
 This directory is part of the awesome-readme project.
 ## Directory Tree
 [<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
 ```
 src/
-   │   README.md
-   │   buildReadme.ts
-   │   cli.ts
-   │   filterFiles.ts
-   │   index.ts
-   │   types.ts
-   │   writeReadme.ts
+   ├─── README.md
+   ├─── buildReadme.ts
+   ├─── cli.ts
+   ├─── filterFiles.ts
+   ├─── index.ts
+   ├─── tree.ts
+   ├─── types.ts
+   └─── writeReadme.ts
 ```
 ## Don't hesitate to contribute to this project.

--- a/src/buildReadme.ts
+++ b/src/buildReadme.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 
 import { listFilteredFiles } from './filterFiles';
+import { renderTreeRows, type TreeEntry } from './tree';
 import type { ExtraData } from './types';
 import { writeReadmeFile, type ReadmeWriteMode } from './writeReadme';
 
@@ -22,31 +23,23 @@ const buildReadme = (
     // Shared with the root walk so `ignore_files`, `.git*` and `.gitignore`
     // rules are applied consistently at every depth.
     const files = listFilteredFiles(currentPath, extraData);
-    const directory: string[] = [];
-    const currentFiles: string[] = [];
+    const entries: TreeEntry[] = files.map((name) => {
+      const filePath = currentPath + '/' + name;
+      const stats = fs.statSync(filePath);
+      return { name, isDirectory: stats.isDirectory() };
+    });
 
     let directoryFileList = '';
     let currentFilesList = '';
-    let directoryTree = '';
-
-    // identify if the files are directories or files
-    files.map((file) => {
-      const filePath = currentPath + '/' + file;
-      const stats = fs.statSync(filePath);
-      if (stats.isDirectory()) {
-        directory.push(file);
-        directoryFileList += ` - [${file}/](./${file}/)\r`;
-      } else {
-        currentFiles.push(file);
-        currentFilesList += ` - [${file}](./${file})\r`;
-      }
+    entries.forEach((entry) => {
+      if (entry.isDirectory) directoryFileList += ` - [${entry.name}/](./${entry.name}/)\r`;
+      else currentFilesList += ` - [${entry.name}](./${entry.name})\r`;
     });
-    currentFiles.forEach((element) => {
-      directoryTree += '   ' + `│   ${element}\n`;
-    });
-    directory.forEach((element) => {
-      directoryTree += '   ' + `└─── ${element}/\n`;
-    });
+    // Subdirectory children are rendered with `├───`/`└───` connectors and
+    // indented one level under the parent (`prefix`), so the tree still
+    // looks like a proper tree when it is read on its own in the sub-README.
+    const treeLines = renderTreeRows(entries).map((line) => `${prefix}${line}`);
+    const directoryTree = treeLines.join('\n');
     const directoryTreePrefix = `\`\`\`\n${file}/\n`;
     const directoryTreeSuffix = `\`\`\``;
     const buildReadme = `
@@ -58,7 +51,7 @@ ${extraData.sub_header}
 ${directoryFileList ? '## Directories\n' + directoryFileList + '\n' : ''}
 ${currentFilesList ? currentFilesList : ''}
 ${extraData.sub_body}
-${directoryTree ? '## Directory Tree\n[<- Previous](' + repositoryUrl + ')\n' + directoryTreePrefix + directoryTree + directoryTreeSuffix : ''}
+${directoryTree ? '## Directory Tree\n[<- Previous](' + repositoryUrl + ')\n' + directoryTreePrefix + directoryTree + '\n' + directoryTreeSuffix : ''}
 ${extraData.sub_footer}
 `;
     writeReadmeFile(currentPath, buildReadme, mode);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import figletLib from 'figlet';
 import buildReadme from './buildReadme';
 import { parseCliOptions, usage, type CliOptions } from './cli';
 import { listFilteredFiles } from './filterFiles';
+import { renderTreeRows, type TreeEntry } from './tree';
 import type { ExtraData } from './types';
 import { writeReadmeFile, type ReadmeWriteMode } from './writeReadme';
 
@@ -138,75 +139,90 @@ ${rendered}
   if (extraData.ignore_files.length > 0) console.log('\x1b[33m', 'Ignoring files: ', '\x1b[0m', extraData.ignore_files.toString());
 
   const files = listFilteredFiles(currentPath, extraData);
-  const directory: string[] = [];
-  const currentFiles: string[] = [];
-  // Map each subdirectory name to its rendered tree text so it can be nested
-  // under that directory in the parent tree instead of being dumped at the bottom.
-  const subDirectoryTreeMap: Record<string, string> = {};
+  const entries: TreeEntry[] = files.map((file) => {
+    const filePath = path.resolve(currentPath, file);
+    const stats = fs.statSync(filePath);
+    return { name: file, isDirectory: stats.isDirectory() };
+  });
+  const fileEntries = entries.filter((entry) => !entry.isDirectory);
+  const directoryEntries = entries.filter((entry) => entry.isDirectory);
+  // Map each subdirectory name to the nested lines from its own tree so they
+  // can be inlined under the parent's directory entry rather than dumped at
+  // the bottom of the root tree.
+  const subDirectoryTreeMap: Record<string, string[]> = {};
 
   let directoryFileList = '';
   let currentFilesList = '';
-  let directoryTree = `\`\`\`\n` + repositoryName + '/\n';
 
-  // identify if the files are directories or files
-  files.map((file) => {
-    const filePath = path.resolve(currentPath, file);
-    const stats = fs.statSync(filePath);
-    if (stats.isDirectory()) {
-      directory.push(file);
-      directoryFileList += ` - [${file}/](./${file}/)\r`;
-      const addToTree = buildReadme(file, filePath + '/', repositoryName + ' / ' + file, figlet, licenseBadge, '', repositoryUrl, '   ', extraData, subMode);
-      subDirectoryTreeMap[file] = addToTree ?? '';
-      // Second-level walk: filter here too, otherwise an ignored directory
-      // would still get a README generated for it.
-      const subDirectoryFiles = listFilteredFiles(filePath + '/', extraData);
-      if (subDirectoryFiles.length > 0)
-        subDirectoryFiles.map((subDirectoryFile) => {
-          const subDirectoryPath = path.resolve(filePath + '/' + subDirectoryFile);
-          const subDirectoryPathStats = fs.statSync(subDirectoryPath);
-          if (subDirectoryPathStats.isDirectory()) {
-            buildReadme(
-              subDirectoryFile,
-              filePath + '/' + subDirectoryFile + '/',
-              repositoryName + ' / ' + file + ' / ' + subDirectoryFile,
-              figlet,
-              licenseBadge,
-              '',
-              repositoryUrl,
-              '   ',
-              extraData,
-              subMode
-            );
-          }
-        });
-    } else {
-      currentFiles.push(file);
-      currentFilesList += ` - [${file}](./${file})\n`;
-    }
-    return { file, type: stats.isDirectory() ? 'directory' : 'file' };
+  // Walk the same directory listing once, building the link list, the
+  // subdirectory tree map and the grandchild README list in lock-step so
+  // the rendering helpers stay the only place that knows about box-drawing
+  // characters.
+  directoryEntries.forEach((entry) => {
+    const filePath = path.resolve(currentPath, entry.name);
+    directoryFileList += ` - [${entry.name}/](./${entry.name}/)\r`;
+    const subTree = buildReadme(
+      entry.name,
+      filePath + '/',
+      repositoryName + ' / ' + entry.name,
+      figlet,
+      licenseBadge,
+      '',
+      repositoryUrl,
+      '   ',
+      extraData,
+      subMode
+    );
+    // The subdirectory tree is rendered with a '   ' prefix so it sits one
+    // level deep in isolation. Strip those three spaces here so the parent
+    // can prepend its own continuation indent cleanly when nesting.
+    subDirectoryTreeMap[entry.name] = (subTree ?? '')
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => line.replace(/^ {3}/, ''));
+    // Second-level walk: filter here too, otherwise an ignored directory
+    // would still get a README generated for it.
+    const subDirectoryFiles = listFilteredFiles(filePath + '/', extraData);
+    if (subDirectoryFiles.length > 0)
+      subDirectoryFiles.forEach((subDirectoryFile) => {
+        const subDirectoryPath = path.resolve(filePath + '/' + subDirectoryFile);
+        const subDirectoryPathStats = fs.statSync(subDirectoryPath);
+        if (subDirectoryPathStats.isDirectory()) {
+          buildReadme(
+            subDirectoryFile,
+            filePath + '/' + subDirectoryFile + '/',
+            repositoryName + ' / ' + entry.name + ' / ' + subDirectoryFile,
+            figlet,
+            licenseBadge,
+            '',
+            repositoryUrl,
+            '   ',
+            extraData,
+            subMode
+          );
+        }
+      });
   });
-  currentFiles.forEach((element) => {
-    directoryTree += `│   ${element}\n`;
+  fileEntries.forEach((entry) => {
+    currentFilesList += ` - [${entry.name}](./${entry.name})\n`;
   });
-  directory.forEach((element, index) => {
-    const isLast = index === directory.length - 1;
-    const connector = isLast ? '└───' : '├───';
-    // Children of a non-last directory are drawn with a `│` so the parent's
-    // connector column continues; children of the last directory use blanks.
+  // The root tree and the subdirectory trees share the same renderer, so
+  // connectors and last-child logic stay consistent. Files are rendered
+  // first to match the existing root layout, then directories with their
+  // subtrees inlined under each one. The file and directory lists are
+  // rendered as separate batches so each group closes on its own last
+  // child (`└───`), which keeps the visual layout intact.
+  const treeLines: string[] = [`${repositoryName}/`];
+  renderTreeRows(fileEntries).forEach((line) => treeLines.push(line));
+  const directoryLines = renderTreeRows(directoryEntries);
+  directoryEntries.forEach((entry, index) => {
+    const isLast = index === directoryEntries.length - 1;
     const childIndent = isLast ? '    ' : '│   ';
-    directoryTree += `${connector} ${element}/\n`;
-    // Nest the subdirectory's tree immediately under its directory entry so
-    // files from different subdirectories are no longer mixed at the bottom.
-    const subTree = subDirectoryTreeMap[element] || '';
-    subTree.split('\n').forEach((line) => {
-      if (line === '') return;
-      // buildReadme prefixes each of its lines with three spaces so that the
-      // subdirectory's tree lines up one level deep. Replace that prefix with
-      // the parent's child indent so the lines sit under the right connector.
-      directoryTree += `${childIndent}${line.replace(/^ {3}/, '')}\n`;
-    });
+    treeLines.push(directoryLines[index]);
+    const subTreeLines = subDirectoryTreeMap[entry.name] || [];
+    subTreeLines.forEach((line) => treeLines.push(`${childIndent}${line}`));
   });
-  directoryTree += `\`\`\``;
+  const directoryTree = `\`\`\`\n${treeLines.join('\n')}\n\`\`\``;
   const buildReadmeData = `
 ${licenseBadge}${licenseBadge ? '\n' : ''}${extraData.root_license}
 

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,0 +1,52 @@
+/**
+ * Render a directory tree as a list of plain-text lines.
+ *
+ * The root README in `src/index.ts` and the per-subdirectory READMEs in
+ * `src/buildReadme.ts` used to maintain their own tree strings, which let
+ * the two paths drift apart (the subdirectory path hard-coded every
+ * directory connector to `└───` and walked children with a slightly
+ * different ordering). This helper is the single source of truth for both
+ * callers so the connectors, last-child logic and child indent stay in
+ * lock-step.
+ *
+ * Each call renders one level of siblings. Files and directories are
+ * treated as siblings (both draw `├───`/`└───` connectors), which removes
+ * the visual `│   │   file` collision that the previous `│   ` continuation
+ * column produced when the subtree was nested under a non-last parent.
+ */
+
+/**
+ * One entry to render in a tree.
+ *
+ * The caller is responsible for stat-ing each entry so `isDirectory`
+ * reflects the actual filesystem entry. The tree renderer does not touch
+ * the filesystem so it stays cheap and easy to test.
+ */
+export interface TreeEntry {
+  name: string;
+  isDirectory: boolean;
+}
+
+/**
+ * Render a list of sibling entries into tree lines.
+ *
+ * Each line is prefixed with `├───` (or `└───` for the last child) and
+ * directories are suffixed with `/`. The function does not draw the parent
+ * line or any leading continuation indent — the caller prepends those.
+ *
+ * Returning an array (instead of a joined string) keeps the call sites
+ * honest about where each line boundary lives, so the parent can prepend
+ * its own per-line child indent when nesting.
+ */
+export const renderTreeRows = (entries: TreeEntry[]): string[] => {
+  const lines: string[] = [];
+  entries.forEach((entry, index) => {
+    const isLast = index === entries.length - 1;
+    const connector = isLast ? '└───' : '├───';
+    const suffix = entry.isDirectory ? '/' : '';
+    lines.push(`${connector} ${entry.name}${suffix}`);
+  });
+  return lines;
+};
+
+export default renderTreeRows;

--- a/test/README.md
+++ b/test/README.md
@@ -16,14 +16,15 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [cli.test.js](./cli.test.js) - [filterFiles.test.js](./filterFiles.test.js)
+ - [README.md](./README.md) - [cli.test.js](./cli.test.js) - [filterFiles.test.js](./filterFiles.test.js) - [tree.test.js](./tree.test.js)
 This directory is part of the awesome-readme project.
 ## Directory Tree
 [<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
 ```
 test/
-   │   README.md
-   │   cli.test.js
-   │   filterFiles.test.js
+   ├─── README.md
+   ├─── cli.test.js
+   ├─── filterFiles.test.js
+   └─── tree.test.js
 ```
 ## Don't hesitate to contribute to this project.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -180,3 +180,99 @@ test('an unknown flag exits non-zero and prints the usage', () => {
   assert.match(stderr, /Usage: awesome-readme/);
   assert.ok(usage.includes('--root-only'));
 });
+
+// Regression coverage for #82: the subdirectory tree used to render every
+// directory entry as `└───`, and the root tree mixed files with the
+// continuation column. The generator now shares one tree renderer between
+// the root and subdirectory paths, so the two layouts have to stay in sync.
+test('subdirectory trees use the same connectors and last-child rule as the root tree', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-tree-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'demo',
+      license: 'MIT',
+      repository: { type: 'git', url: 'git+https://github.com/demo/demo.git' }
+    })
+  );
+  // Two files at the root plus two subdirectories, so the root tree has a
+  // non-last and a last directory entry.
+  fs.writeFileSync(path.join(root, 'README.md'), '');
+  fs.writeFileSync(path.join(root, 'LICENSE'), '');
+  fs.mkdirSync(path.join(root, 'alpha'));
+  fs.mkdirSync(path.join(root, 'beta'));
+  fs.writeFileSync(path.join(root, 'alpha', 'a.txt'), '');
+  fs.writeFileSync(path.join(root, 'beta', 'b.txt'), '');
+
+  try {
+    captureOutput(() => main(['--path', root]));
+
+    const rootReadme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+    // Root tree: two non-last directory connectors and one last child.
+    assert.match(rootReadme, /├─── alpha\//);
+    assert.match(rootReadme, /└─── beta\//);
+    // Subtree lines under a non-last directory use the `│   ` continuation
+    // column so the parent's connector column continues.
+    assert.match(rootReadme, /│   └─── a\.txt/);
+
+    const alphaReadme = fs.readFileSync(path.join(root, 'alpha', 'README.md'), 'utf8');
+    // Subdirectory tree: a single file is the last child, so it uses
+    // `└───` (and the previous code wrongly used `└───` for every entry).
+    assert.match(alphaReadme, /└─── a\.txt/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Snapshot-style assertion: locks the expected ASCII tree for the canonical
+// layout (files followed by directories, subtrees inlined under their
+// parent). Locks both the root README and the subdirectory README so the
+// two paths cannot drift apart again.
+test('generated trees match the issue #82 fixture', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-snapshot-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'demo',
+      license: 'MIT',
+      repository: { type: 'git', url: 'git+https://github.com/demo/demo.git' }
+    })
+  );
+  fs.writeFileSync(path.join(root, 'README.md'), '');
+  fs.mkdirSync(path.join(root, 'docs'));
+  fs.mkdirSync(path.join(root, 'src'));
+  fs.writeFileSync(path.join(root, 'docs', 'notes.md'), '');
+
+  const extractTree = (readme) => {
+    // The root README has the figlet code block then the tree block; the
+    // subdirectory README has a `[<- Previous](url)` link line between the
+    // `## Directory Tree` heading and the tree's fence. Anchor on the
+    // heading and grab the last fenced block, which is always the tree.
+    const blocks = readme.match(/```\n[\s\S]*?\n```/g);
+    if (!blocks || blocks.length === 0) return '';
+    const treeBlock = blocks[blocks.length - 1];
+    // Strip the surrounding fences.
+    return treeBlock.replace(/^```\n/, '').replace(/\n```$/, '');
+  };
+
+  try {
+    captureOutput(() => main(['--path', root]));
+
+    const rootTree = extractTree(fs.readFileSync(path.join(root, 'README.md'), 'utf8'));
+    const expectedRootTree = [
+      'demo/',
+      '├─── README.md',
+      '└─── package.json',
+      '├─── docs/',
+      '│   └─── notes.md',
+      '└─── src/'
+    ].join('\n');
+    assert.strictEqual(rootTree, expectedRootTree);
+
+    const docsTree = extractTree(fs.readFileSync(path.join(root, 'docs', 'README.md'), 'utf8'));
+    const expectedDocsTree = ['docs/', '   └─── notes.md'].join('\n');
+    assert.strictEqual(docsTree, expectedDocsTree);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/tree.test.js
+++ b/test/tree.test.js
@@ -1,0 +1,99 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const { renderTreeRows } = require('../dist/tree');
+
+test('renderTreeRows emits a single line per entry in the given order', () => {
+  const entries = [
+    { name: 'README.md', isDirectory: false },
+    { name: 'src', isDirectory: true },
+    { name: 'test', isDirectory: true }
+  ];
+
+  assert.deepStrictEqual(renderTreeRows(entries), [
+    '├─── README.md',
+    '├─── src/',
+    '└─── test/'
+  ]);
+});
+
+test('renderTreeRows uses ├─── for every non-last entry', () => {
+  const entries = [
+    { name: 'a', isDirectory: true },
+    { name: 'b', isDirectory: true },
+    { name: 'c', isDirectory: true }
+  ];
+
+  // The last child still closes the tree even when there are no files.
+  assert.deepStrictEqual(renderTreeRows(entries), ['├─── a/', '├─── b/', '└─── c/']);
+});
+
+test('renderTreeRows closes on a single-entry list', () => {
+  const entries = [{ name: 'only', isDirectory: true }];
+
+  assert.deepStrictEqual(renderTreeRows(entries), ['└─── only/']);
+});
+
+test('renderTreeRows treats files and directories as siblings', () => {
+  // Files and directories share the same `├───`/`└───` rule, so the caller
+  // can hand the full entry list in one call and still get a balanced tree.
+  const entries = [
+    { name: 'README.md', isDirectory: false },
+    { name: 'package.json', isDirectory: false },
+    { name: 'docs', isDirectory: true }
+  ];
+
+  assert.deepStrictEqual(renderTreeRows(entries), [
+    '├─── README.md',
+    '├─── package.json',
+    '└─── docs/'
+  ]);
+});
+
+// Regression coverage for #82: the subdirectory tree used to render every
+// directory entry as `└───`, which made the closing rule wrong even when
+// there were multiple sibling directories.
+test('renderTreeRows distinguishes non-last and last directories among siblings', () => {
+  const entries = [
+    { name: 'first', isDirectory: true },
+    { name: 'second', isDirectory: true },
+    { name: 'third', isDirectory: true }
+  ];
+
+  const lines = renderTreeRows(entries);
+
+  // First two use the open connector, last uses the close connector.
+  assert.strictEqual(lines[0], '├─── first/');
+  assert.strictEqual(lines[1], '├─── second/');
+  assert.strictEqual(lines[2], '└─── third/');
+  // No line ends with `└───` for a non-last entry.
+  assert.ok(lines.slice(0, -1).every((line) => line.startsWith('├─── ')));
+});
+
+test('renderTreeRows returns an empty array for no entries', () => {
+  assert.deepStrictEqual(renderTreeRows([]), []);
+});
+
+// Snapshot of the canonical ASCII tree the README + sub-README should
+// produce. This is the layout the issue calls for: `├───`/`└───` connectors
+// for both files and directories, with the last child closing the bracket.
+test('renderTreeRows matches the issue #82 fixture tree', () => {
+  const entries = [
+    { name: 'README.md', isDirectory: false },
+    { name: 'package.json', isDirectory: false },
+    { name: 'docs', isDirectory: true },
+    { name: 'src', isDirectory: true },
+    { name: 'test', isDirectory: true }
+  ];
+
+  const tree = renderTreeRows(entries).join('\n');
+  const expected = [
+    '├─── README.md',
+    '├─── package.json',
+    '├─── docs/',
+    '├─── src/',
+    '└─── test/'
+  ].join('\n');
+
+  assert.strictEqual(tree, expected);
+});


### PR DESCRIPTION
Fixes #82

The root tree already used proper '`├───`' / '`└───`' connectors and last-child logic; `src/buildReadme.ts` duplicated the tree-building loop but hard-coded every directory entry to '`└───`' and a different layout, so subdirectory trees closed the bracket on every dir regardless of position and the two paths could drift apart.

This commit introduces `src/tree.ts` as the single source of truth: one `renderTreeRows` helper that draws '`├───`' for non-last siblings and '`└───`' for the last sibling, for both files and directories. Both the root tree and the subdirectory trees now share the same connectors and last-child logic, so the tree closes on the same child in both views.

Files and directories are treated as siblings (both draw '`├───`' / '`└───`'), which removes the visual '`│   │   `' collision that the previous '`│   `' continuation column produced when a subdirectory tree was nested under a non-last parent.

Tests:

- `test/tree.test.js` covers the helper's connector rule, last-child logic, single-entry list, empty list, and the canonical fixture tree from #82.
- `test/cli.test.js` adds an end-to-end snapshot test that locks the generated root tree and subdirectory tree against the expected ASCII trees, so the two paths cannot drift apart again.