### PR TITLE
fix: make lint cover real sources and gate type errors in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  lint-and-build:
-    name: Lint & build
+  verify:
+    name: Lint, typecheck, build & test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,5 +29,13 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+      # TypeScript sources are not covered by ESLint (typescript-eslint does not
+      # support TS 7 yet), so tsc is what actually gates type errors. See #79.
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,24 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 1. Open a issue first or pickup a existing issue, to not start working on improvement that we may judge out of scope for this project
 
-2. Ensure to run linter and ensure the result of your changes can be build without errors
+2. Run the same checks CI runs, and make sure they all pass:
 
 ```
-npm run lint:fix
-
-npm run build
+npm run lint          # ESLint over JavaScript files
+npm run format:check  # Prettier formatting
+npm run typecheck     # tsc --noEmit, catches type errors in src/
+npm run build         # compile src/ to dist/
+npm test              # build, then run the test suite
 ```
+
+`npm run lint:fix` (Prettier `--write`) will fix most formatting complaints for you.
+
+> **Note on TypeScript linting:** ESLint only covers `.js` files here. The project
+> builds with TypeScript 7, and `typescript-eslint` does not support the TS 7 API yet
+> ([typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940)),
+> so `src/**/*.ts` is excluded from ESLint. Type errors in `src/` are caught by
+> `npm run typecheck` instead. When typescript-eslint gains TS >=7.1 support, the
+> ignore entry in `eslint.config.js` should be removed.
 
 3. Document the new features, or functionality in README.md
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,32 +1,45 @@
 const js = require('@eslint/js');
 
+// NOTE ON TYPESCRIPT SOURCES (see issue #79)
+//
+// `src/**/*.ts` is intentionally NOT linted by ESLint. This project builds with
+// TypeScript 7, and typescript-eslint refuses to load against the TS 7 API:
+//
+//   "typescript-eslint does not support TS 7.0."
+//
+// The guard lives in @typescript-eslint/parser itself, so every route into it
+// (flat config preset, bare parser, type-aware rules) throws at require time.
+// Upstream tracking: https://github.com/typescript-eslint/typescript-eslint/issues/10940
+//
+// Until that lands, type safety for `src/` is enforced by `npm run typecheck`
+// (`tsc --noEmit`) in CI, not by ESLint. Once typescript-eslint supports TS >=7.1,
+// drop the ignore below and extend it with `tseslint.configs.recommended`.
+
 module.exports = [
+  {
+    ignores: ['node_modules/**', 'dist/**', 'src/**/*.ts']
+  },
   js.configs.recommended,
   {
-    ignores: ['node_modules/**', 'dist/**']
-  },
-  {
-    files: ['src/**/*.js'],
+    files: ['**/*.js'],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: 'commonjs',
       globals: {
         require: 'readonly',
-        module: 'readonly',
+        module: 'writable',
+        exports: 'writable',
         process: 'readonly',
         __dirname: 'readonly',
         __filename: 'readonly',
-        console: 'readonly'
+        console: 'readonly',
+        Buffer: 'readonly'
       }
     },
     rules: {
-      'no-console': 0,
-      'no-unused-vars': 0,
-      'no-undef': 0,
-      'no-debugger': 0,
-      'no-alert': 0,
-      'no-empty': 0,
-      'no-extra-semi': 0
+      // A CLI writes to stdout by design.
+      'no-console': 'off',
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
     }
   }
 ];

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "prettier --write \"src/**/*.{js,ts}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts}\"",
     "build": "tsc",
-    "test": "npm run build && node --test test/",
+    "test": "npm run build && node --test",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "awesome-readme": "node ./dist/index.js",
-    "lint": "find src -name '*.js' -type f -exec eslint -- {} +",
+    "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "lint:fix": "prettier --write \"src/**/*.{js,ts}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts}\"",

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -213,7 +213,7 @@ test('subdirectory trees use the same connectors and last-child rule as the root
     assert.match(rootReadme, /└─── beta\//);
     // Subtree lines under a non-last directory use the `│   ` continuation
     // column so the parent's connector column continues.
-    assert.match(rootReadme, /│   └─── a\.txt/);
+    assert.match(rootReadme, /│ {3}└─── a\.txt/);
 
     const alphaReadme = fs.readFileSync(path.join(root, 'alpha', 'README.md'), 'utf8');
     // Subdirectory tree: a single file is the last child, so it uses


### PR DESCRIPTION
Closes #79

## The bug

The `lint` script was:

```
find src -name '*.js' -type f -exec eslint -- {} +
```

Every file under `src/` is TypeScript, so `find` matched nothing, the
`-exec ... +` body never ran, and `eslint` was never invoked. CI called
`npm run lint`, got exit code 0, and reported a green lint check while linting
zero files.

Confirmed on `main` before changing anything: `npm run lint` exits 0, and
`find src -name '*.js' -type f | wc -l` returns `0`.

## Why typescript-eslint is not used

The issue suggests configuring typescript-eslint. That path is currently
closed. This project builds with TypeScript 7.0.2, and typescript-eslint
aborts at require time:

```
typescript-eslint does not support TS 7.0.
```

The guard lives in `@typescript-eslint/parser` itself, so the flat-config
preset, the bare parser, and type-aware rules all throw. I verified all three.
Upstream tracking: https://github.com/typescript-eslint/typescript-eslint/issues/10940

The only way I found to make it run is aliasing a second TypeScript 6 copy and
monkeypatching Node's module resolver from inside `eslint.config.js`. That
works, but a resolver patch in a lint config is not worth it, so I took the
fallback the issue itself allows ("at minimum run `npm run typecheck` in CI").

## Changes

- `lint` is now `eslint .`, which lints the JavaScript that actually exists
  (root configs and `test/`).
- `src/**/*.ts` is explicitly ignored, with the reason and the removal
  condition recorded in `eslint.config.js`.
- CI gains a `typecheck` step, so type errors in `src/` fail the build.
- CI also runs the test suite; the job is renamed to match what it does.
- ESLint config cleanup: the old rule block disabled `no-unused-vars`,
  `no-undef`, and `no-empty` for files it was never applied to. `no-console`
  stays off (a CLI writes to stdout by design); `no-unused-vars` is now an
  error with an `^_` escape hatch. Added the `exports` and `Buffer` globals.

Enabling lint surfaced one pre-existing violation: a `no-regex-spaces` error
on a tree-connector assertion in `test/cli.test.js`. The three spaces are the
intended continuation column, so they are now spelled `{3}` rather than
weakening the assertion.

## Verification

All five checks pass locally:

| check | exit |
|---|---|
| `npm run lint` | 0 |
| `npm run format:check` | 0 |
| `npm run typecheck` | 0 |
| `npm run build` | 0 |
| `npm test` | 0 (32/32) |

Since the bug was a check that could not fail, I also confirmed both gates now
actually fail:

- Adding a JS file with a redeclared variable: `npm run lint` exits 1
  (`no-redeclare`, `no-useless-assignment`).
- Adding `const x: number = "not a number"` to `src/tree.ts`:
  `npm run typecheck` exits 1 (`error TS2322`). The file was restored.

Branch protection on `main` has no required status checks configured, so
renaming the job does not orphan a required check.

## Acceptance criteria

- [x] CI fails on TypeScript type errors — via `npm run typecheck`, verified
      failing on an injected type error
- [x] Lint (or documented equivalent) covers `.ts` sources — `tsc --noEmit`
      is the documented equivalent; the ESLint gap and its removal condition
      are recorded in `eslint.config.js`
- [x] `npm run lint` / `typecheck` documented in CONTRIBUTING


---

## Follow-up: the new test step exposed a broken test script

Adding `npm test` to CI made it fail immediately, which was a real bug rather
than a problem with the CI change:

- `node --test test/` fails on **Node 24**. A bare directory argument is no
  longer taken as a search path; Node resolves it as a module entry point and
  exits with `MODULE_NOT_FOUND`. CI runs Node 24.
- A quoted glob (`"test/*.test.js"`) fixes Node 24 but breaks **Node 18 and 20**,
  where `--test` glob support does not exist yet and the pattern is taken
  literally. `package.json` declares `node >=18`, so that form is not acceptable
  either.

The script is now just `node --test`. Node's own test-file discovery works on
every supported version, and it picks up new `test/*.test.js` files
automatically, so a future test file cannot silently go unrun — the same
failure mode this PR fixes for lint.

Verified `npm test` green on Node 18, 20, and 24 (32/32 each). CI now passes
all steps: Lint, Check formatting, Typecheck, Build, Test.
