### PR TITLE
fix: finish CONTRIBUTING hygiene

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,8 @@ npm run build         # compile src/ to dist/
 npm test              # build, then run the test suite
 ```
 
-`npm run lint:fix` (Prettier `--write`) will fix most formatting complaints for you.
+`npm run format` (Prettier `--write`) and `npm run lint:fix` (ESLint `--fix`)
+will fix most lint and formatting complaints for you.
 
 > **Note on TypeScript linting:** ESLint only covers `.js` files here. The project
 > builds with TypeScript 7, and `typescript-eslint` does not support the TS 7 API yet
@@ -90,7 +91,10 @@ further defined and clarified by project maintainers.
 ### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported privately through the project's
+[GitHub Security Advisories](https://github.com/marc-aurele-besner/awesome-readme/security/advisories/new)
+page, which creates a private channel between the reporter and the maintainers.
+All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
   "scripts": {
     "awesome-readme": "node ./dist/index.js",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit",
-    "lint:fix": "prettier --write \"src/**/*.{js,ts}\"",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"src/**/*.{js,ts}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts}\"",
+    "typecheck": "tsc --noEmit",
     "build": "tsc",
     "test": "npm run build && node --test",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
Closes #92.

## Summary

Three small CONTRIBUTING-hygiene fixes bundled together since they all
touch the contributor-facing surface and share an acceptance criterion:

1. **Replace the CoC placeholder.** `[INSERT EMAIL ADDRESS]` is gone.
   Reports are now routed through the project's GitHub Security Advisories
   page, which gives reporters a private channel that doesn't expose the
   maintainers' inbox.
2. **Rename the misleading `lint:fix` script.** It used to run Prettier
   `--write`. It now runs `eslint . --fix`, which is what the name
   promises. The old behaviour lives at a new script: `format` (Prettier
   `--write`).
3. **Align CONTRIBUTING.md with reality.** The script list and the
   "fix complaints" hint now reference `format` and `lint:fix` as they
   actually behave.

## Acceptance criteria

- [x] No `[INSERT EMAIL ADDRESS]` placeholder remains
- [x] Contributor docs match actual npm scripts

## Verification

`npm run lint`, `npm run format:check`, `npm run typecheck`,
`npm run build`, and `npm test` (32/32 passing) all run cleanly.
The new `lint:fix` (`eslint . --fix`) and `format`
(`prettier --write`) scripts both behave as their names suggest.