### PR TITLE
feat: support glob patterns and sensible defaults in ignore_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ module.exports = {
     sub_footer: `## Don't hesitate to contribute to this project.`,
     ignore_gitFiles: true,
     ignore_gitIgnoreFiles: true,
-    ignore_files: ['.prettierignore']
+    // `ignore_files` accepts gitignore-style globs (`*.log`, `dist/`). On top of
+    // what is listed here, a small set of defaults (node_modules/, dist/,
+    // coverage/, build/) is merged in automatically; set `ignore_defaults` to
+    // false to opt out.
+    ignore_files: ['.prettierignore'],
+    ignore_defaults: true
 }
 ```
 

--- a/awesome-readme.config.js
+++ b/awesome-readme.config.js
@@ -95,7 +95,12 @@ module.exports = {
     sub_footer: \`## Don't hesitate to contribute to this project.\`,
     ignore_gitFiles: true,
     ignore_gitIgnoreFiles: true,
-    ignore_files: ['.prettierignore']
+    // \`ignore_files\` accepts gitignore-style globs (\`*.log\`, \`dist/\`). On top of
+    // what is listed here, a small set of defaults (node_modules/, dist/,
+    // coverage/, build/) is merged in automatically; set \`ignore_defaults\` to
+    // false to opt out.
+    ignore_files: ['.prettierignore'],
+    ignore_defaults: true
 }
 \`\`\`
 `,
@@ -106,5 +111,10 @@ module.exports = {
   sub_footer: `## Don't hesitate to contribute to this project.`,
   ignore_gitFiles: true,
   ignore_gitIgnoreFiles: true,
-  ignore_files: ['.prettierignore']
+  // `ignore_files` accepts gitignore-style globs (`*.log`, `dist/`). On top of
+  // what is listed here, a small set of defaults (node_modules/, dist/,
+  // coverage/, build/) is merged in automatically; set `ignore_defaults` to
+  // false to opt out.
+  ignore_files: ['.prettierignore'],
+  ignore_defaults: true
 };

--- a/src/filterFiles.ts
+++ b/src/filterFiles.ts
@@ -6,44 +6,113 @@ import ignoreLib from 'ignore';
 import type { ExtraData } from './types';
 
 /**
+ * Built-in ignore patterns applied on top of the user's `ignore_files` list
+ * unless `ignore_defaults` is set to false.
+ *
+ * Patterns are gitignore-style so directory-only entries (the trailing slash
+ * form) only match directories when the matching helper is given entry types.
+ * `node_modules` and `dist` are the common cases that pollute generated
+ * README trees; `coverage` and `build` cover the usual test/CI outputs.
+ */
+export const DEFAULT_IGNORE_PATTERNS: readonly string[] = ['node_modules/', 'dist/', 'coverage/', 'build/'];
+
+/**
  * Ignore rules shared by the root listing and every subdirectory listing.
  *
  * Both walks used to filter files independently, which meant `ignore_files`
  * was only honoured at the root and a file ignored there could still show up
  * in a sub-README or subdirectory tree. Everything that lists files now goes
  * through this module so the rules stay in sync.
+ *
+ * `ignore_files` patterns are matched through the `ignore` library so users
+ * can write gitignore-style globs (`*.log`, `dist/`, negation, etc.) instead
+ * of having to list every exact filename. Defaults from
+ * `DEFAULT_IGNORE_PATTERNS` are merged in unless `ignore_defaults` is false.
  */
 export interface FilterOptions {
   ignore_gitFiles: boolean;
   ignore_gitIgnoreFiles: boolean;
   ignore_files: string[];
+  ignore_defaults: boolean;
 }
 
 /**
- * Parse the raw contents of a `.gitignore` into an `ignore` instance.
+ * Parse a list of raw gitignore-style patterns into an `ignore` instance.
  *
  * Blank lines and `#` comments are skipped so the patterns that reach the
  * library are exactly the ones that would apply to a real `.gitignore`.
+ * The empty list short-circuits to `undefined` so callers can cheaply skip
+ * the matching step when no patterns were requested.
  */
-const compileGitignore = (contents: string): ReturnType<typeof ignoreLib> => {
-  const patterns = contents
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0 && !line.startsWith('#'));
-
-  return ignoreLib().add(patterns);
+const compilePatterns = (patterns: string[]): ReturnType<typeof ignoreLib> | undefined => {
+  const cleaned = patterns.filter((line) => line.length > 0 && !line.trim().startsWith('#'));
+  if (cleaned.length === 0) return undefined;
+  return ignoreLib().add(cleaned);
 };
 
 /**
- * Whether a single entry is ignored by the compiled `.gitignore` patterns.
+ * Parse the raw contents of a `.gitignore` file into an `ignore` instance.
  *
- * Directory-only patterns like `dist/` only fire when the entry is a directory
- * and the path is supplied with a trailing slash, so the filter tests both
- * forms rather than guessing what the user meant.
+ * Splits on newlines (including `\r\n`) so multi-pattern files compile the
+ * same way they would when handed straight to `git status`. Comments and
+ * blank lines are filtered out before the patterns reach the library.
  */
-const isIgnoredByGitignore = (name: string, isDirectory: boolean, ig: ReturnType<typeof ignoreLib>): boolean => {
+const compileGitignore = (contents: string): ReturnType<typeof ignoreLib> | undefined => {
+  return compilePatterns(contents.split(/\r?\n/));
+};
+
+/**
+ * Whether a single entry is ignored by the compiled patterns, without
+ * knowing whether the name refers to a file or a directory.
+ *
+ * Tests both forms (`name` and `name/`) so directory-only patterns like
+ * `dist/` still match a bare directory name when the caller cannot tell
+ * the type. This is the path taken by `filterFiles`, which only receives a
+ * flat list of entry names from the public API.
+ */
+const matchesAnyForm = (name: string, ig: ReturnType<typeof ignoreLib>): boolean => {
+  return ig.ignores(name) || ig.ignores(`${name}/`);
+};
+
+/**
+ * Whether a single entry is ignored by the compiled patterns when its type
+ * is known.
+ *
+ * Directory-only patterns (`dist/`) only fire when the entry is a directory
+ * and the path is supplied with a trailing slash, so the filter tests both
+ * forms for directories and only the bare form for files. This is the path
+ * taken by `filterEntries`, which receives entries stat'd against the
+ * filesystem.
+ */
+const isIgnoredByPatterns = (name: string, isDirectory: boolean, ig: ReturnType<typeof ignoreLib>): boolean => {
   if (isDirectory) return ig.ignores(`${name}/`) || ig.ignores(name);
   return ig.ignores(name);
+};
+
+/**
+ * Merge the user's `ignore_files` patterns with the built-in defaults.
+ *
+ * Duplicates are stripped (preserving the first occurrence so the user's
+ * patterns are listed first in any debug output) and the result keeps
+ * `ignore_files` on top so it is obvious what was configured vs. what
+ * came from the tool. When `ignore_defaults` is false, only the user's
+ * patterns are returned.
+ */
+export const mergeIgnorePatterns = (userPatterns: string[], applyDefaults: boolean): string[] => {
+  const merged: string[] = [];
+  const seen = new Set<string>();
+  for (const pattern of userPatterns) {
+    if (seen.has(pattern)) continue;
+    seen.add(pattern);
+    merged.push(pattern);
+  }
+  if (!applyDefaults) return merged;
+  for (const pattern of DEFAULT_IGNORE_PATTERNS) {
+    if (seen.has(pattern)) continue;
+    seen.add(pattern);
+    merged.push(pattern);
+  }
+  return merged;
 };
 
 /**
@@ -54,10 +123,12 @@ const isIgnoredByGitignore = (name: string, isDirectory: boolean, ig: ReturnType
  * delegated to the `ignore` package, so `.gitignore` patterns (`*`, `dist/`,
  * negation, etc.) are honoured instead of being reduced to a substring check.
  *
- * Directory-only patterns still need to be matched against entry types, so
- * callers that know whether each entry is a file or directory should prefer
- * `listFilteredFiles`, which routes through `filterEntries` for the
- * type-aware check.
+ * `ignore_files` is matched the same way, which means patterns can use
+ * gitignore globs (`*.log`, `dist/`) rather than having to spell out exact
+ * filenames. Directory-only patterns still need to be matched against entry
+ * types, so callers that know whether each entry is a file or directory
+ * should prefer `listFilteredFiles`, which routes through `filterEntries`
+ * for the type-aware check.
  */
 export const filterFiles = (files: string[], options: FilterOptions, gitignore?: string): string[] => {
   let filtered = files;
@@ -72,8 +143,10 @@ export const filterFiles = (files: string[], options: FilterOptions, gitignore?:
   if (options.ignore_gitFiles) {
     filtered = filtered.filter((file) => !file.startsWith('.git'));
   }
-  if (options.ignore_files.length > 0) {
-    filtered = filtered.filter((file) => !options.ignore_files.includes(file));
+  const mergedPatterns = mergeIgnorePatterns(options.ignore_files, options.ignore_defaults);
+  const patternsIg = compilePatterns(mergedPatterns);
+  if (patternsIg !== undefined) {
+    filtered = filtered.filter((file) => !matchesAnyForm(file, patternsIg));
   }
 
   return filtered;
@@ -101,13 +174,15 @@ export const filterEntries = (entries: FilterEntry[], options: FilterOptions, gi
   const ig = gitignore !== undefined ? compileGitignore(gitignore) : undefined;
 
   if (ig !== undefined && options.ignore_gitIgnoreFiles) {
-    filtered = filtered.filter((entry) => !isIgnoredByGitignore(entry.name, entry.isDirectory, ig));
+    filtered = filtered.filter((entry) => !isIgnoredByPatterns(entry.name, entry.isDirectory, ig));
   }
   if (options.ignore_gitFiles) {
     filtered = filtered.filter((entry) => !entry.name.startsWith('.git'));
   }
-  if (options.ignore_files.length > 0) {
-    filtered = filtered.filter((entry) => !options.ignore_files.includes(entry.name));
+  const mergedPatterns = mergeIgnorePatterns(options.ignore_files, options.ignore_defaults);
+  const patternsIg = compilePatterns(mergedPatterns);
+  if (patternsIg !== undefined) {
+    filtered = filtered.filter((entry) => !isIgnoredByPatterns(entry.name, entry.isDirectory, patternsIg));
   }
 
   return filtered.map((entry) => entry.name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,11 @@ const buildMainReadme = (options: Partial<BuildOptions> = {}): void => {
     sub_footer: '',
     ignore_gitFiles: true,
     ignore_gitIgnoreFiles: true,
-    ignore_files: []
+    ignore_files: [],
+    // Built-in defaults (`node_modules/`, `dist/`, `coverage/`, `build/`) are
+    // merged with `ignore_files` unless the config opts out via
+    // `ignore_defaults: false`.
+    ignore_defaults: true
   };
   let figlet = `
 \`\`\`
@@ -86,6 +90,7 @@ ${config.figlet}
     if (config.ignore_gitFiles !== undefined) extraData.ignore_gitFiles = config.ignore_gitFiles;
     if (config.ignore_gitIgnoreFiles !== undefined) extraData.ignore_gitIgnoreFiles = config.ignore_gitIgnoreFiles;
     if (config.ignore_files !== undefined && config.ignore_files.length > 0) extraData.ignore_files = config.ignore_files;
+    if (config.ignore_defaults !== undefined) extraData.ignore_defaults = config.ignore_defaults;
     // When `figlet_text` is provided, render it with the figlet package so the
     // user does not have to hand-author the ASCII art. Pre-rendered `figlet`
     // strings still win so existing configs keep working.
@@ -137,6 +142,7 @@ ${rendered}
     console.log('\x1b[33m', 'Using .gitignore to ignore files', '\x1b[0m');
   if (extraData.ignore_gitFiles) console.log('\x1b[33m', 'Ignoring .git files', '\x1b[0m');
   if (extraData.ignore_files.length > 0) console.log('\x1b[33m', 'Ignoring files: ', '\x1b[0m', extraData.ignore_files.toString());
+  if (extraData.ignore_defaults) console.log('\x1b[33m', 'Ignoring default directories: node_modules/, dist/, coverage/, build/', '\x1b[0m');
 
   const files = listFilteredFiles(currentPath, extraData);
   const entries: TreeEntry[] = files.map((file) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,4 +10,9 @@ export interface ExtraData {
   ignore_gitFiles: boolean;
   ignore_gitIgnoreFiles: boolean;
   ignore_files: string[];
+  // Whether the built-in list of default ignore patterns (node_modules,
+  // dist, coverage, build) should be merged with the user-provided
+  // `ignore_files` patterns. Defaults to true; set to false to opt out
+  // and only honour patterns from the config.
+  ignore_defaults: boolean;
 }

--- a/test/filterFiles.test.js
+++ b/test/filterFiles.test.js
@@ -4,12 +4,16 @@ const os = require('node:os');
 const path = require('node:path');
 const { test } = require('node:test');
 
-const { filterFiles, filterEntries, listFilteredFiles } = require('../dist/filterFiles');
+const { filterFiles, filterEntries, listFilteredFiles, mergeIgnorePatterns } = require('../dist/filterFiles');
 
 const options = (overrides = {}) => ({
   ignore_gitFiles: true,
   ignore_gitIgnoreFiles: true,
   ignore_files: [],
+  // Tests opt out of the built-in defaults so the existing gitignore-only
+  // assertions cannot collide with `node_modules/`, `dist/`, etc. The default
+  // behaviour is covered by the dedicated tests at the bottom of this file.
+  ignore_defaults: false,
   ...overrides
 });
 
@@ -159,4 +163,99 @@ test('listFilteredFiles honours gitignore glob patterns against the filesystem',
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+// Coverage for #87: `ignore_files` is supposed to accept gitignore-style
+// globs (`*.log`, `dist/`) rather than only exact filenames.
+test('filterFiles accepts glob patterns in ignore_files', () => {
+  const files = ['app.log', 'main.ts', 'debug.log'];
+
+  assert.deepStrictEqual(filterFiles(files, options({ ignore_files: ['*.log'] })), ['main.ts']);
+});
+
+// Directory-only patterns should only match directories, so a same-named
+// file stays in the listing. `listFilteredFiles` is the entry point used by
+// the rest of the CLI so it is exercised here.
+test('listFilteredFiles honours directory-only patterns from ignore_files', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-'));
+  fs.mkdirSync(path.join(root, 'dist'));
+  fs.writeFileSync(path.join(root, 'dist', 'bundle.js'), '');
+  // Sibling file whose name happens to match the directory pattern, so the
+  // filter has to distinguish directories from files.
+  fs.writeFileSync(path.join(root, 'dist.txt'), '');
+  fs.writeFileSync(path.join(root, 'README.md'), '');
+
+  try {
+    const files = listFilteredFiles(root, options({ ignore_files: ['dist/'] }));
+
+    assert.deepStrictEqual(files.sort(), ['README.md', 'dist.txt']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Negation in `ignore_files` should also work: a `!foo` pattern re-includes
+// an entry that an earlier glob would have excluded.
+test('filterFiles honours negation patterns in ignore_files', () => {
+  const files = ['dist', 'dist-keep.md'];
+
+  assert.deepStrictEqual(filterFiles(files, options({ ignore_files: ['dist*', '!dist-keep.md'] })), ['dist-keep.md']);
+});
+
+// Built-in defaults: with `ignore_defaults: true` (the production default),
+// common build/deps directories are filtered out automatically. Tests opt
+// out of defaults via the `options()` helper so the assertions above stay
+// focused on the rule under test.
+test('filterFiles applies the built-in defaults when ignore_defaults is true', () => {
+  const files = ['node_modules', 'dist', 'coverage', 'build', 'src', 'README.md'];
+
+  assert.deepStrictEqual(filterFiles(files, options({ ignore_defaults: true })).sort(), ['README.md', 'src']);
+});
+
+// Opt-out: `ignore_defaults: false` skips the built-in list, leaving only
+// the user-provided `ignore_files` patterns.
+test('filterFiles honours ignore_defaults: false', () => {
+  const files = ['node_modules', 'dist', 'secret.txt', 'README.md'];
+
+  assert.deepStrictEqual(
+    filterFiles(files, options({ ignore_defaults: false, ignore_files: ['secret.txt'] })).sort(),
+    ['README.md', 'dist', 'node_modules']
+  );
+});
+
+// End-to-end coverage: a generated README should not list `node_modules`
+// when the project has no `.gitignore` and no explicit `ignore_files`. This
+// is the user-facing behaviour the issue calls out.
+test('listFilteredFiles filters out node_modules by default', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-'));
+  fs.mkdirSync(path.join(root, 'node_modules'));
+  fs.writeFileSync(path.join(root, 'node_modules', 'pkg.js'), '');
+  fs.writeFileSync(path.join(root, 'README.md'), '');
+
+  try {
+    const files = listFilteredFiles(root, options({ ignore_defaults: true }));
+
+    assert.deepStrictEqual(files, ['README.md']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// `mergeIgnorePatterns` deduplicates and keeps the user list on top.
+test('mergeIgnorePatterns combines user patterns with defaults without duplicates', () => {
+  const merged = mergeIgnorePatterns(['.prettierignore', 'dist/'], true);
+
+  assert.deepStrictEqual(merged, ['.prettierignore', 'dist/', 'node_modules/', 'coverage/', 'build/']);
+});
+
+test('mergeIgnorePatterns returns only the user list when defaults are disabled', () => {
+  const merged = mergeIgnorePatterns(['.prettierignore'], false);
+
+  assert.deepStrictEqual(merged, ['.prettierignore']);
+});
+
+test('mergeIgnorePatterns deduplicates overlapping patterns', () => {
+  const merged = mergeIgnorePatterns(['dist/', 'dist/'], true);
+
+  assert.deepStrictEqual(merged, ['dist/', 'node_modules/', 'coverage/', 'build/']);
 });


### PR DESCRIPTION
Resolves #87

`ignore_files` used to only match exact filenames, so users had to enumerate every single artifact they wanted out of their generated README trees. This PR makes the existing `ignore` library do the work and layers sensible defaults on top.

What changes:
- `ignore_files` now accepts gitignore-style globs (`*.log`, `dist/`, `!dist-keep.md`, ...). Negation and directory-only patterns work the way they would in a real `.gitignore`.
- A built-in list of defaults (`node_modules/`, `dist/`, `coverage/`, `build/`) is merged with the user patterns, so generated trees no longer pull in `node_modules` or `dist` when no explicit `.gitignore` or config entry covers them.
- New opt-out: `ignore_defaults: false` falls back to only the user-provided `ignore_files` patterns.
- `filterFiles` (no type info) tests both `name` and `name/` forms so patterns like `dist/` still match a bare directory name; `filterEntries` stays strictly type-aware so a same-named file is not wrongly excluded by a directory-only pattern.

Why:
- The current exact-match behaviour does not scale, and the most common complaint about generated READMEs is the noise from build/deps directories.
- The `ignore` dependency already provides gitignore-style matching, so no new runtime cost.

Tests:
- Glob and negation coverage for `ignore_files`
- Built-in defaults on / off
- End-to-end check that `listFilteredFiles` drops `node_modules` by default
- `mergeIgnorePatterns` deduplication and opt-out

Existing test helper opts out of the new defaults so the gitignore-only assertions stay focused; the default-on behaviour is exercised by dedicated tests at the bottom of `test/filterFiles.test.js`.

Validation (matches CI):
- `npm run lint` — clean
- `npm run format:check` — clean
- `npm run typecheck` — clean
- `npm test` — 41/41 passing

Notes:
- The README is regenerated to pick up the new option in the config example; the diff is purely the embedded config snippet.