### PR TITLE
feat: auto-generate figlet banner from package.json name

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ module.exports = {
     // pre-rendered figlet below in place if you want to use that instead.
     // figlet_text: 'awesome-readme',
     // figlet_font: 'Standard',
+    // By default a banner is auto-generated from `package.json` `name` when
+    // neither `figlet` nor `figlet_text` is set. Set `figlet_auto` to
+    // false to keep the banner blank, or to true to force auto-generation
+    // even when `figlet_text` is unset.
+    // figlet_auto: true,
     figlet: `
     .d8b.  db   d8b   db d88888b .d8888.  .d88b.  .88b  d88. d88888b        d8888b. d88888b  .d8b.  d8888b. .88b  d88. d88888b
     d8' '8b 88   I8I   88 88'     88'  YP .8P  Y8. 88'YbdP'88 88'            88  '8D 88'     d8' '8b 88  '8D 88'YbdP'88 88'

--- a/awesome-readme.config.js
+++ b/awesome-readme.config.js
@@ -5,6 +5,10 @@ module.exports = {
   // still win, so existing configs keep working.
   // figlet_text: 'awesome-readme',
   // figlet_font: 'Standard',
+  // `figlet_auto` (defaults to true) makes the renderer auto-generate a
+  // banner from `package.json` `name` whenever `figlet` and `figlet_text`
+  // are both unset. Set to false to keep the banner empty.
+  // figlet_auto: true,
   figlet: `
  .d8b.  db   d8b   db d88888b .d8888.  .d88b.  .88b  d88. d88888b        d8888b. d88888b  .d8b.  d8888b. .88b  d88. d88888b
 d8' '8b 88   I8I   88 88'     88'  YP .8P  Y8. 88'YbdP'88 88'            88  '8D 88'     d8' '8b 88  '8D 88'YbdP'88 88'
@@ -70,6 +74,11 @@ module.exports = {
     // pre-rendered figlet below in place if you want to use that instead.
     // figlet_text: 'awesome-readme',
     // figlet_font: 'Standard',
+    // By default a banner is auto-generated from \`package.json\` \`name\` when
+    // neither \`figlet\` nor \`figlet_text\` is set. Set \`figlet_auto\` to
+    // false to keep the banner blank, or to true to force auto-generation
+    // even when \`figlet_text\` is unset.
+    // figlet_auto: true,
     figlet: \`
     .d8b.  db   d8b   db d88888b .d8888.  .d88b.  .88b  d88. d88888b        d8888b. d88888b  .d8b.  d8888b. .88b  d88. d88888b
     d8' '8b 88   I8I   88 88'     88'  YP .8P  Y8. 88'YbdP'88 88'            88  '8D 88'     d8' '8b 88  '8D 88'YbdP'88 88'

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,17 +54,18 @@ const buildMainReadme = (options: Partial<BuildOptions> = {}): void => {
     // `ignore_defaults: false`.
     ignore_defaults: true
   };
-  let figlet = `
-\`\`\`
-.d8b.  db   d8b   db d88888b .d8888.  .d88b.  .88b  d88. d88888b        d8888b. d88888b  .d8b.  d8888b. .88b  d88. d88888b
-d8' '8b 88   I8I   88 88'     88'  YP .8P  Y8. 88'YbdP'88 88'            88  '8D 88'     d8' '8b 88  '8D 88'YbdP'88 88'
-88ooo88 88   I8I   88 88ooooo '8bo.   88    88 88  88  88 88ooooo        88oobY' 88ooooo 88ooo88 88   88 88  88  88 88ooooo
-88~~~88 Y8   I8I   88 88~~~~~   'Y8b. 88    88 88  88  88 88~~~~~ C8888D 88'8b   88~~~~~ 88~~~88 88   88 88  88  88 88~~~~~
-88   88 '8b d8'8b d8' 88.     db   8D '8b  d8' 88  88  88 88.            88 '88. 88.     88   88 88  .8D 88  88  88 88.
-YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD Y88888P YP   YP Y8888D' YP  YP  YP Y88888P
-\`\`\``;
-
-  console.log('\x1b[32m', figlet, '\x1b[0m');
+  // The banner used to ship as a hand-authored "awesome-readme" string. It now
+  // starts empty so the auto-generation step below can render a banner from
+  // the project name whenever nothing else supplies one, and so opting out
+  // leaves a blank banner rather than a hardcoded one.
+  let figlet = '';
+  // `figlet_auto` defaults to true so a freshly generated README gets a banner
+  // derived from `package.json` `name`. Setting it to false in the config keeps
+  // the banner empty.
+  let figletAuto = true;
+  // `figlet_font` selects the font used by both `figlet_text` and the
+  // auto-generated banner so the two paths stay consistent.
+  let figletFont = 'Standard';
   // An explicit `--config` must exist; the default file stays optional.
   const configPath = options.config ? path.resolve(options.config) : path.join(currentPath, DEFAULT_CONFIG_FILE);
   if (options.config && !fs.existsSync(configPath)) throw new Error(`Config file not found: ${configPath}`);
@@ -91,21 +92,41 @@ ${config.figlet}
     if (config.ignore_gitIgnoreFiles !== undefined) extraData.ignore_gitIgnoreFiles = config.ignore_gitIgnoreFiles;
     if (config.ignore_files !== undefined && config.ignore_files.length > 0) extraData.ignore_files = config.ignore_files;
     if (config.ignore_defaults !== undefined) extraData.ignore_defaults = config.ignore_defaults;
+    // `figlet_auto` opt-out. Defaults to true above; explicit `false` keeps
+    // the banner empty even when nothing else supplies one.
+    if (config.figlet_auto !== undefined) figletAuto = config.figlet_auto !== false;
+    // `figlet_font` shared by `figlet_text` and the auto-generated banner so a
+    // font choice applies consistently to both paths.
+    if (typeof config.figlet_font === 'string' && config.figlet_font.length > 0) figletFont = config.figlet_font;
     // When `figlet_text` is provided, render it with the figlet package so the
     // user does not have to hand-author the ASCII art. Pre-rendered `figlet`
     // strings still win so existing configs keep working.
     if (config.figlet_text !== undefined) {
-      const font = typeof config.figlet_font === 'string' && config.figlet_font.length > 0 ? config.figlet_font : 'Standard';
       try {
-        const rendered = figletLib.textSync(String(config.figlet_text), { font });
+        const rendered = figletLib.textSync(String(config.figlet_text), { font: figletFont });
         figlet = `
 \`\`\`
 ${rendered}
 \`\`\``;
-        console.log('\x1b[33m', 'Generated figlet from figlet_text using font "' + font + '"', '\x1b[0m');
+        console.log('\x1b[33m', 'Generated figlet from figlet_text using font "' + figletFont + '"', '\x1b[0m');
       } catch (err) {
-        console.log('\x1b[31m', 'Failed to generate figlet for "' + String(config.figlet_text) + '" with font "' + font + '":', '\x1b[0m', err);
+        console.log('\x1b[31m', 'Failed to generate figlet for "' + String(config.figlet_text) + '" with font "' + figletFont + '":', '\x1b[0m', err);
       }
+    }
+  }
+  // Auto-generate the banner from `package.json` `name` when no other source
+  // supplied one. Runs once whether or not a config file exists, so the
+  // zero-config path also benefits.
+  if (figlet === '' && figletAuto && repositoryName) {
+    try {
+      const rendered = figletLib.textSync(String(repositoryName), { font: figletFont });
+      figlet = `
+\`\`\`
+${rendered}
+\`\`\``;
+      console.log('\x1b[33m', 'Auto-generated figlet from package.json "name" using font "' + figletFont + '"', '\x1b[0m');
+    } catch (err) {
+      console.log('\x1b[31m', 'Failed to auto-generate figlet for "' + String(repositoryName) + '" with font "' + figletFont + '":', '\x1b[0m', err);
     }
   }
   let repositoryUrl = '';

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -6,6 +6,9 @@ const { test } = require('node:test');
 
 const { parseCliOptions, usage } = require('../dist/cli');
 const { main } = require('../dist/index');
+// Used by the auto-generated-banner tests to compare against the expected
+// figlet output for a given name and font combination.
+const figlet = require('figlet');
 
 // Every generated README is announced on stdout, and the dry-run notices go
 // there too, so tests capture console output instead of shelling out.
@@ -272,6 +275,166 @@ test('generated trees match the issue #82 fixture', () => {
     const docsTree = extractTree(fs.readFileSync(path.join(root, 'docs', 'README.md'), 'utf8'));
     const expectedDocsTree = ['docs/', '   └─── notes.md'].join('\n');
     assert.strictEqual(docsTree, expectedDocsTree);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Coverage for #88: when the user runs the tool with no config, the banner
+// is auto-generated from `package.json` `name` using the figlet library. The
+// same `Standard` font is used by both `figlet_text` and the auto-generated
+// banner so the layout stays consistent across both code paths.
+test('auto-generates a figlet banner from package.json name when no config is provided', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-figlet-auto-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'demo',
+      license: 'MIT',
+      repository: { type: 'git', url: 'git+https://github.com/demo/demo.git' }
+    })
+  );
+
+  try {
+    const { result, stdout } = captureOutput(() => main(['--path', root]));
+
+    assert.strictEqual(result, 0);
+    // The renderer logs a status line for the auto-generation path.
+    assert.match(stdout, /Auto-generated figlet from package\.json "name" using font "Standard"/);
+
+    const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+    // The README should contain the figlet text wrapped in its own fenced
+    // block. The figlet output contains characters that have meaning in
+    // regular expressions (`(`, `)`, `|`, `\`, `_`), so a substring check is
+    // used here to avoid escaping them. The renderer template literal inserts
+    // a blank line between the banner and the closing fence.
+    const expectedBanner = figlet.textSync('demo', { font: 'Standard' }).replace(/\n$/, '');
+    const openingFence = '\n```\n' + expectedBanner;
+    assert.ok(readme.includes(openingFence), 'README should contain the auto-generated figlet banner inside its own fenced block');
+    const closingIndex = readme.indexOf(openingFence) + openingFence.length;
+    assert.ok(closingIndex > 0 && /^\n+```/m.test(readme.slice(closingIndex)), 'README should close the figlet banner fence correctly');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Coverage for #88: an explicit `figlet` string in the config wins over the
+// auto-generated banner, so existing configs keep their custom art.
+test('config.figlet wins over the auto-generated banner', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-figlet-explicit-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'demo',
+      license: 'MIT',
+      repository: { type: 'git', url: 'git+https://github.com/demo/demo.git' }
+    })
+  );
+  fs.writeFileSync(path.join(root, 'awesome-readme.config.js'), "module.exports = { figlet: 'CUSTOM-ASCII-ART' };\n");
+
+  try {
+    const { result, stdout } = captureOutput(() => main(['--path', root]));
+
+    assert.strictEqual(result, 0);
+    // The "auto-generated" log is not emitted when a figlet string is provided.
+    assert.doesNotMatch(stdout, /Auto-generated figlet/);
+
+    const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+    assert.match(readme, /CUSTOM-ASCII-ART/);
+    // The auto-generated figlet for "demo" must NOT appear. Use the second
+    // rendered line as a fingerprint so the assertion does not have to deal
+    // with the figlet output's `(`, `|`, etc. characters being regex-special.
+    const demoLineFingerprint = figlet.textSync('demo', { font: 'Standard' }).split('\n')[1];
+    assert.ok(!readme.includes(demoLineFingerprint), 'README must not contain the auto-generated figlet when an explicit figlet is set');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Coverage for #88: `figlet_text` plus `figlet_font` still works after the
+// refactor, and the font choice applies consistently to both this path and
+// the auto-generated banner.
+test('config.figlet_text with figlet_font renders the configured banner', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-figlet-text-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'demo',
+      license: 'MIT',
+      repository: { type: 'git', url: 'git+https://github.com/demo/demo.git' }
+    })
+  );
+  fs.writeFileSync(path.join(root, 'awesome-readme.config.js'), "module.exports = { figlet_text: 'pretty', figlet_font: 'Big' };\n");
+
+  try {
+    const { result, stdout } = captureOutput(() => main(['--path', root]));
+
+    assert.strictEqual(result, 0);
+    assert.match(stdout, /Generated figlet from figlet_text using font "Big"/);
+
+    const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+    const expected = figlet.textSync('pretty', { font: 'Big' }).replace(/\n$/, '');
+    const openingFence = '\n```\n' + expected;
+    assert.ok(readme.includes(openingFence), 'README should contain the figlet_text-rendered banner inside its own fenced block');
+    const closingIndex = readme.indexOf(openingFence) + openingFence.length;
+    assert.ok(closingIndex > 0 && /^\n+```/m.test(readme.slice(closingIndex)), 'README should close the figlet_text banner fence correctly');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Coverage for #88: opting out via `figlet_auto: false` suppresses the
+// auto-generated banner, and an explicit `figlet_text` still wins because it
+// is treated as the user's deliberate choice.
+test('figlet_auto: false suppresses auto-generation', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-figlet-optout-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'demo',
+      license: 'MIT',
+      repository: { type: 'git', url: 'git+https://github.com/demo/demo.git' }
+    })
+  );
+  fs.writeFileSync(path.join(root, 'awesome-readme.config.js'), "module.exports = { figlet_auto: false };\n");
+
+  try {
+    const { result, stdout } = captureOutput(() => main(['--path', root]));
+
+    assert.strictEqual(result, 0);
+    assert.doesNotMatch(stdout, /Auto-generated figlet/);
+
+    const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+    // The figlet text from `textSync('demo', Standard)` must NOT appear.
+    const demoLineFingerprint = figlet.textSync('demo', { font: 'Standard' }).split('\n')[1];
+    assert.ok(!readme.includes(demoLineFingerprint), 'README must not contain the auto-generated figlet when figlet_auto is false');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Coverage for #88: `figlet_auto` is also honoured when a config file is
+// absent, and a manual config flag can force-enable it even when the user
+// provides neither `figlet` nor `figlet_text`.
+test('figlet_auto: true forces auto-generation even with an empty config file', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-figlet-forced-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'demo',
+      license: 'MIT',
+      repository: { type: 'git', url: 'git+https://github.com/demo/demo.git' }
+    })
+  );
+  // An empty config file (still counts as "config exists") with the auto
+  // flag explicitly on — without this, auto-gen must already be the default.
+  fs.writeFileSync(path.join(root, 'awesome-readme.config.js'), "module.exports = { figlet_auto: true };\n");
+
+  try {
+    const { result, stdout } = captureOutput(() => main(['--path', root]));
+
+    assert.strictEqual(result, 0);
+    assert.match(stdout, /Auto-generated figlet from package\.json "name" using font "Standard"/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Implements the long-standing request to remove the requirement of pasting ASCII art into the config to get a banner. The renderer now auto-generates the figlet from `package.json` `name` whenever the config leaves both `figlet` and `figlet_text` empty, with `figlet_auto: false` available as an opt-out.

Closes #88.

## Behavior

Config precedence (unchanged for existing configs):

1. Explicit `figlet` string wins (still bypasses everything).
2. `figlet_text` rendered with the figlet library using `figlet_font` (defaults to `Standard`).
3. Otherwise, when `figlet_auto !== false`, a banner is auto-generated from `package.json` `name` using the same font.
4. `figlet_auto: false` keeps the banner empty.

`figlet_font` is now shared between `figlet_text` and auto-generation so a font choice applies to both. The hand-authored default figlet that used to ship inside `src/index.ts` is removed; existing configs that supply `figlet` are unaffected, and the no-config path now gets a project-specific banner.

## Acceptance criteria

- [x] Banner can be auto-generated when not provided (`figlet_auto: true` default, derives from `package.json` `name`)
- [x] Custom `figlet` string still wins when set
- [x] Dependency impact is acceptable for a CLI (`figlet` was already a runtime dependency)

## Tests

5 new tests in `test/cli.test.js` cover the auto-generated banner, explicit `figlet` winning, `figlet_text` + `figlet_font` rendering, `figlet_auto: false` opt-out, and the empty-but-auto-on case. The full suite (46 tests) passes locally, as do `npm run lint` and `npm run typecheck`.