### PR TITLE
fix: stop publishing TypeScript source to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   ],
   "files": [
     "dist/",
-    "src/",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
Closes #84

The `files` field in package.json listed `src/` next to `dist/`, so
every published tarball shipped the TypeScript source alongside the
compiled CLI. Consumers only need `dist/` to run `awesome-readme`, so
the source files just added noise and bulk to the package.

This removes `src/` from the files list.

### Before

```
npm pack --dry-run
# 39 files, 27.9 kB / 109.9 kB unpacked
# src/buildReadme.ts, src/cli.ts, src/filterFiles.ts, src/index.ts, src/README.md,
# src/tree.ts, src/types.ts, src/writeReadme.ts — all shipped.
```

### After

```
npm pack --dry-run
# 31 files, 21.0 kB / 76.9 kB unpacked
```

Acceptance criteria from #84:

- [x] `npm pack --dry-run` shows only intended files (LICENSE, README.md, dist/, package.json)
- [x] Installed package still exposes a working `awesome-readme` bin — verified locally by installing the tarball and running `awesome-readme --help`

Local checks (lint, typecheck, format:check, build, full test suite — 46/46) all pass.