### PR TITLE
feat: preserve hand-written README content across regenerations

### DIFF
--- a/awesome-readme.config.js
+++ b/awesome-readme.config.js
@@ -48,7 +48,16 @@ Options:
   -p, --path <dir>      Project root to generate READMEs for (default: current directory)
   -c, --config <file>   Path to the config file (default: <path>/awesome-readme.config.js)
       --root-only       Only write the root README, skip subdirectory READMEs
+      --force           Overwrite existing READMEs entirely, discarding their content
+      --if-missing      Only create READMEs for directories that do not have one
 \`\`\`
+
+Existing READMEs are never clobbered: generated content lives between
+\`<!-- awesome-readme:start -->\` and \`<!-- awesome-readme:end -->\` markers
+and only that region is regenerated on the next run. A README without markers
+is left untouched unless \`--force\` is passed. To regenerate part of a
+hand-written README, wrap the section you want the tool to own with the two
+markers.
 
 Preview the output before touching your files:
 
@@ -61,6 +70,17 @@ Generate for another project, with a config living elsewhere:
 \`\`\`
 npx awesome-readme --path ./packages/core --config ./readme.config.js
 \`\`\`
+
+Add the markers to a hand-written README to opt into partial regeneration:
+
+\`\`\`
+<!-- awesome-readme:start -->
+<!-- awesome-readme:end -->
+\`\`\`
+
+Fill the gap with anything you want the tool to own (a tree, a badge list, an
+auto-generated file index, etc.) and the next run will refresh that block
+without touching the rest of the file.
 `,
   root_body: `
 

--- a/src/buildReadme.ts
+++ b/src/buildReadme.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import { listFilteredFiles } from './filterFiles';
 import { renderTreeRows, type TreeEntry } from './tree';
 import type { ExtraData } from './types';
-import { writeReadmeFile, type ReadmeWriteMode } from './writeReadme';
+import { writeReadmeFile, type ReadmeWriteMode, type ReadmeWriteOptions } from './writeReadme';
 
 const buildReadme = (
   file: string,
@@ -16,8 +16,9 @@ const buildReadme = (
   prefix = '',
   extraData: ExtraData,
   // The directory tree is returned to the caller regardless of the mode, so
-  // `--root-only` and `--dry-run` still render a complete root README.
-  mode: ReadmeWriteMode = 'write'
+  // `--root-only` and `--dry-run` still render a complete root README. Accepts
+  // either a bare mode or the full write options (`--force`, `--if-missing`).
+  writeOptions: ReadmeWriteMode | ReadmeWriteOptions = 'write'
 ): string | undefined => {
   if (currentPath) {
     // Shared with the root walk so `ignore_files`, `.git*` and `.gitignore`
@@ -54,7 +55,7 @@ ${extraData.sub_body}
 ${directoryTree ? '## Directory Tree\n[<- Previous](' + repositoryUrl + ')\n' + directoryTreePrefix + directoryTree + '\n' + directoryTreeSuffix : ''}
 ${extraData.sub_footer}
 `;
-    writeReadmeFile(currentPath, buildReadme, mode);
+    writeReadmeFile(currentPath, buildReadme, writeOptions);
     return directoryTree;
   }
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,10 @@ export interface CliOptions {
   help: boolean;
   dryRun: boolean;
   rootOnly: boolean;
+  /** Overwrite existing READMEs wholesale instead of preserving their content. */
+  force: boolean;
+  /** Only generate READMEs for directories that do not have one yet. */
+  ifMissing: boolean;
   path?: string;
   config?: string;
 }
@@ -19,18 +23,27 @@ export const usage = `Usage: awesome-readme [options]
 
 Generate README.md files for a project and its subdirectories.
 
+Existing READMEs are never clobbered: generated content lives between
+<!-- awesome-readme:start --> and <!-- awesome-readme:end --> markers and only
+that region is regenerated. A README without markers is left untouched unless
+--force is passed.
+
 Options:
   -h, --help            Show this help message and exit
       --dry-run         Print what would be written without writing any file
   -p, --path <dir>      Project root to generate READMEs for (default: current directory)
   -c, --config <file>   Path to the config file (default: <path>/awesome-readme.config.js)
       --root-only       Only write the root README, skip subdirectory READMEs
+      --force           Overwrite existing READMEs entirely, discarding their content
+      --if-missing      Only create READMEs for directories that do not have one
 
 Examples:
   awesome-readme
   awesome-readme --dry-run
   awesome-readme --path ./packages/core --config ./readme.config.js
-  awesome-readme --root-only`;
+  awesome-readme --root-only
+  awesome-readme --if-missing
+  awesome-readme --force`;
 
 /**
  * Parse `process.argv.slice(2)` into `CliOptions`.
@@ -50,6 +63,8 @@ export const parseCliOptions = (argv: string[]): CliOptions => {
         help: { type: 'boolean', short: 'h', default: false },
         'dry-run': { type: 'boolean', default: false },
         'root-only': { type: 'boolean', default: false },
+        force: { type: 'boolean', default: false },
+        'if-missing': { type: 'boolean', default: false },
         path: { type: 'string', short: 'p' },
         config: { type: 'string', short: 'c' }
       }
@@ -62,6 +77,8 @@ export const parseCliOptions = (argv: string[]): CliOptions => {
     help?: boolean;
     'dry-run'?: boolean;
     'root-only'?: boolean;
+    force?: boolean;
+    'if-missing'?: boolean;
     path?: string;
     config?: string;
   };
@@ -70,11 +87,16 @@ export const parseCliOptions = (argv: string[]): CliOptions => {
   // request to use the default, so reject it instead of silently falling back.
   if (values.path !== undefined && values.path.trim() === '') throw new Error('Option --path requires a directory.');
   if (values.config !== undefined && values.config.trim() === '') throw new Error('Option --config requires a file path.');
+  // `--force` overwrites everything and `--if-missing` refuses to touch any
+  // existing file: asking for both is a contradiction, not a precedence puzzle.
+  if (values.force === true && values['if-missing'] === true) throw new Error('Options --force and --if-missing cannot be combined.');
 
   return {
     help: values.help === true,
     dryRun: values['dry-run'] === true,
     rootOnly: values['root-only'] === true,
+    force: values.force === true,
+    ifMissing: values['if-missing'] === true,
     path: values.path,
     config: values.config
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { parseCliOptions, usage, type CliOptions } from './cli';
 import { listFilteredFiles } from './filterFiles';
 import { renderTreeRows, type TreeEntry } from './tree';
 import type { ExtraData } from './types';
-import { writeReadmeFile, type ReadmeWriteMode } from './writeReadme';
+import { writeReadmeFile, type ReadmeWriteMode, type ReadmeWriteOptions } from './writeReadme';
 
 const DEFAULT_CONFIG_FILE = 'awesome-readme.config.js';
 
@@ -26,6 +26,10 @@ const buildMainReadme = (options: Partial<BuildOptions> = {}): void => {
   // `--root-only` still walks subdirectories because the root directory tree is
   // built from their listings; it just never emits their READMEs.
   const subMode: ReadmeWriteMode = rootOnly ? 'skip' : rootMode;
+  // Content-preservation flags apply to every README the run touches, root and
+  // subdirectories alike.
+  const rootWriteOptions: ReadmeWriteOptions = { mode: rootMode, force: options.force === true, ifMissing: options.ifMissing === true };
+  const subWriteOptions: ReadmeWriteOptions = { ...rootWriteOptions, mode: subMode };
 
   if (!fs.existsSync(currentPath) || !fs.statSync(currentPath).isDirectory()) throw new Error(`Project path not found: ${currentPath}`);
 
@@ -198,7 +202,7 @@ ${rendered}
       repositoryUrl,
       '   ',
       extraData,
-      subMode
+      subWriteOptions
     );
     // The subdirectory tree is rendered with a '   ' prefix so it sits one
     // level deep in isolation. Strip those three spaces here so the parent
@@ -225,7 +229,7 @@ ${rendered}
             repositoryUrl,
             '   ',
             extraData,
-            subMode
+            subWriteOptions
           );
         }
       });
@@ -262,7 +266,7 @@ ${extraData.root_body}
 ${directoryTree ? '## Directory Tree\n' + directoryTree : ''}
 ${extraData.root_footer}
 `;
-  writeReadmeFile(currentPath, buildReadmeData, rootMode);
+  writeReadmeFile(currentPath, buildReadmeData, rootWriteOptions);
 };
 
 /**

--- a/src/writeReadme.ts
+++ b/src/writeReadme.ts
@@ -13,22 +13,120 @@ import * as path from 'path';
 export type ReadmeWriteMode = 'write' | 'dry-run' | 'skip';
 
 /**
+ * Markers delimiting the generated region of a README. Anything outside of
+ * them is hand-written content and is preserved across regenerations, so a
+ * README can mix generated sections with custom prose, badges or docs.
+ */
+export const MARKER_START = '<!-- awesome-readme:start -->';
+export const MARKER_END = '<!-- awesome-readme:end -->';
+
+export interface ReadmeWriteOptions {
+  mode?: ReadmeWriteMode;
+  /**
+   * Never touch a README that already exists (`--if-missing`). Used to fill in
+   * the gaps of a project whose READMEs are otherwise hand-maintained.
+   */
+  ifMissing?: boolean;
+  /**
+   * Replace the whole file, markers and hand-written content included
+   * (`--force`). This is the old, destructive behaviour, now opt-in.
+   */
+  force?: boolean;
+}
+
+/**
+ * What `writeReadmeFile` did (or would do in `dry-run`). Returned so the
+ * behaviour can be asserted without inspecting stdout.
+ */
+export type ReadmeWriteAction = 'created' | 'merged' | 'overwritten' | 'skipped';
+
+/** Wrap freshly generated content in the preservation markers. */
+export const wrapGeneratedContent = (contents: string): string => `${MARKER_START}\n${contents}\n${MARKER_END}\n`;
+
+/**
+ * Replace the marked region of `existing` with `contents`, keeping everything
+ * outside the markers untouched. Returns `undefined` when the file has no
+ * usable marker pair, which tells the caller it is dealing with a fully
+ * hand-written README.
+ */
+export const mergeGeneratedContent = (existing: string, contents: string): string | undefined => {
+  const start = existing.indexOf(MARKER_START);
+  if (start === -1) return undefined;
+  const end = existing.indexOf(MARKER_END, start + MARKER_START.length);
+  if (end === -1) return undefined;
+
+  const before = existing.slice(0, start + MARKER_START.length);
+  const after = existing.slice(end);
+  return `${before}\n${contents}\n${after}`;
+};
+
+/**
  * Single place where README files reach the filesystem, so `--dry-run` cannot
  * be bypassed by one of the two generators forgetting to check it.
+ *
+ * Writing is non-destructive by default:
+ *
+ * - no README yet            → create one, generated content wrapped in markers
+ * - README with markers      → only the marked region is regenerated
+ * - README without markers   → left alone, with a warning telling the user how
+ *                              to opt in (`--force`, or add the markers)
+ * - `--force`                → replace the whole file, markers included
+ * - `--if-missing`           → never touch an existing README
  */
-export const writeReadmeFile = (directoryPath: string, contents: string, mode: ReadmeWriteMode = 'write'): void => {
-  if (mode === 'skip') return;
+export const writeReadmeFile = (directoryPath: string, contents: string, options: ReadmeWriteMode | ReadmeWriteOptions = 'write'): ReadmeWriteAction => {
+  // The mode used to be the third positional argument; accept both shapes so
+  // existing callers (and downstream users of the exported helper) keep working.
+  const { mode = 'write', ifMissing = false, force = false } = typeof options === 'string' ? ({ mode: options } as ReadmeWriteOptions) : options;
+
+  if (mode === 'skip') return 'skipped';
 
   const target = path.join(directoryPath, 'README.md');
+  const exists = fs.existsSync(target);
+  const existing = exists ? fs.readFileSync(target, 'utf8') : '';
 
-  if (mode === 'dry-run') {
-    const action = fs.existsSync(target) ? 'overwrite' : 'create';
-    console.log('\x1b[33m%s\x1b[0m', `[dry-run] Would ${action} ${target} (${Buffer.byteLength(contents, 'utf8')} bytes)`);
-    return;
+  // Decide *what* would happen first, then either report it (`dry-run`) or do
+  // it, so the two paths can never disagree.
+  let action: ReadmeWriteAction;
+  let nextContents = '';
+  let notice = '';
+
+  if (!exists) {
+    action = 'created';
+    nextContents = wrapGeneratedContent(contents);
+  } else if (force) {
+    action = 'overwritten';
+    nextContents = wrapGeneratedContent(contents);
+  } else if (ifMissing) {
+    action = 'skipped';
+    notice = `${target} already exists, skipped (--if-missing)`;
+  } else {
+    const merged = mergeGeneratedContent(existing, contents);
+    if (merged !== undefined) {
+      action = 'merged';
+      nextContents = merged;
+    } else {
+      // A README with no markers is assumed to be hand-written: overwriting it
+      // would silently destroy the user's content, so require an explicit opt-in.
+      action = 'skipped';
+      notice = `${target} has no ${MARKER_START} / ${MARKER_END} markers, left untouched. Add the markers to regenerate part of it, or pass --force to overwrite the whole file.`;
+    }
   }
 
-  fs.writeFileSync(target, contents);
-  console.log('\x1b[32m%s\x1b[0m', 'README.md created in ' + directoryPath, '\x1b[0m');
+  if (action === 'skipped') {
+    console.log('\x1b[33m%s\x1b[0m', `${mode === 'dry-run' ? '[dry-run] ' : ''}${notice}`);
+    return action;
+  }
+
+  if (mode === 'dry-run') {
+    const detail = action === 'merged' ? 'update the generated section of' : action === 'overwritten' ? 'overwrite' : 'create';
+    console.log('\x1b[33m%s\x1b[0m', `[dry-run] Would ${detail} ${target} (${Buffer.byteLength(nextContents, 'utf8')} bytes)`);
+    return action;
+  }
+
+  fs.writeFileSync(target, nextContents);
+  const verb = action === 'merged' ? 'generated section updated in' : action === 'overwritten' ? 'overwritten in' : 'created in';
+  console.log('\x1b[32m%s\x1b[0m', `README.md ${verb} ${directoryPath}`);
+  return action;
 };
 
 export default writeReadmeFile;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -49,6 +49,8 @@ test('parseCliOptions defaults every flag to off', () => {
     help: false,
     dryRun: false,
     rootOnly: false,
+    force: false,
+    ifMissing: false,
     path: undefined,
     config: undefined
   });
@@ -59,12 +61,16 @@ test('parseCliOptions reads long and short forms', () => {
     help: true,
     dryRun: false,
     rootOnly: false,
+    force: false,
+    ifMissing: false,
     path: undefined,
     config: undefined
   });
   assert.strictEqual(parseCliOptions(['-h']).help, true);
   assert.strictEqual(parseCliOptions(['--dry-run']).dryRun, true);
   assert.strictEqual(parseCliOptions(['--root-only']).rootOnly, true);
+  assert.strictEqual(parseCliOptions(['--force']).force, true);
+  assert.strictEqual(parseCliOptions(['--if-missing']).ifMissing, true);
   assert.strictEqual(parseCliOptions(['--path', './pkg']).path, './pkg');
   assert.strictEqual(parseCliOptions(['-p', './pkg']).path, './pkg');
   assert.strictEqual(parseCliOptions(['--config', 'a.js']).config, 'a.js');
@@ -208,7 +214,7 @@ test('subdirectory trees use the same connectors and last-child rule as the root
   fs.writeFileSync(path.join(root, 'beta', 'b.txt'), '');
 
   try {
-    captureOutput(() => main(['--path', root]));
+    captureOutput(() => main(['--path', root, '--force']));
 
     const rootReadme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
     // Root tree: two non-last directory connectors and one last child.
@@ -259,7 +265,7 @@ test('generated trees match the issue #82 fixture', () => {
   };
 
   try {
-    captureOutput(() => main(['--path', root]));
+    captureOutput(() => main(['--path', root, '--force']));
 
     const rootTree = extractTree(fs.readFileSync(path.join(root, 'README.md'), 'utf8'));
     const expectedRootTree = [

--- a/test/preserveReadme.test.js
+++ b/test/preserveReadme.test.js
@@ -1,0 +1,254 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const { main } = require('../dist/index');
+const { MARKER_START, MARKER_END, mergeGeneratedContent, wrapGeneratedContent, writeReadmeFile } = require('../dist/writeReadme');
+
+// Coverage for #86: generating a README must never silently destroy content a
+// user wrote by hand. The generated region is delimited by markers; anything
+// outside of them survives regeneration, and a marker-less README is left
+// alone unless `--force` is passed.
+
+const captureOutput = (fn) => {
+  const stdout = [];
+  const originalLog = console.log;
+  console.log = (...args) => stdout.push(args.join(' '));
+  try {
+    const result = fn();
+    return { result, stdout: stdout.join('\n') };
+  } finally {
+    console.log = originalLog;
+  }
+};
+
+const makeProject = () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-preserve-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'demo',
+      license: 'MIT',
+      repository: { type: 'git', url: 'git+https://github.com/demo/demo.git' }
+    })
+  );
+  fs.mkdirSync(path.join(root, 'src'));
+  fs.writeFileSync(path.join(root, 'src', 'index.js'), '');
+  return root;
+};
+
+const withProject = (fn) => {
+  const root = makeProject();
+  try {
+    fn(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+};
+
+test('a freshly created README wraps its generated content in markers', () => {
+  withProject((root) => {
+    const { result } = captureOutput(() => main(['--path', root]));
+
+    assert.strictEqual(result, 0);
+    const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+    assert.ok(readme.startsWith(MARKER_START), 'generated README should open with the start marker');
+    assert.ok(readme.trimEnd().endsWith(MARKER_END), 'generated README should close with the end marker');
+    assert.match(readme, /# demo/);
+    // Subdirectory READMEs get the same treatment.
+    const subReadme = fs.readFileSync(path.join(root, 'src', 'README.md'), 'utf8');
+    assert.ok(subReadme.startsWith(MARKER_START));
+    assert.ok(subReadme.trimEnd().endsWith(MARKER_END));
+  });
+});
+
+test('hand-written content outside the markers survives regeneration', () => {
+  withProject((root) => {
+    captureOutput(() => main(['--path', root]));
+
+    // Simulate a user adding custom prose above and below the generated block.
+    const readmePath = path.join(root, 'README.md');
+    const generated = fs.readFileSync(readmePath, 'utf8');
+    fs.writeFileSync(readmePath, `# Hand-written title\n\nCUSTOM-INTRO\n\n${generated}\nCUSTOM-OUTRO\n`);
+
+    const { result, stdout } = captureOutput(() => main(['--path', root]));
+
+    assert.strictEqual(result, 0);
+    assert.match(stdout, /generated section updated in/);
+    const updated = fs.readFileSync(readmePath, 'utf8');
+    assert.match(updated, /# Hand-written title/);
+    assert.match(updated, /CUSTOM-INTRO/);
+    assert.match(updated, /CUSTOM-OUTRO/);
+    // And the generated part is still there, exactly once.
+    assert.strictEqual(updated.split(MARKER_START).length - 1, 1);
+    assert.match(updated, /## Directory Tree/);
+  });
+});
+
+test('regenerating is idempotent: markers and structure are preserved across runs', () => {
+  withProject((root) => {
+    captureOutput(() => main(['--path', root]));
+    // Manually stick the README.md back as a plain file so subsequent runs do
+    // not change the file listing (the freshly generated README is itself part
+    // of the tree on the first run, which is the only legitimate source of
+    // growth). This isolates the preservation guarantee from that side effect.
+    fs.writeFileSync(path.join(root, 'README.md'), `${MARKER_START}\nplaceholder\n${MARKER_END}\n`);
+
+    captureOutput(() => main(['--path', root]));
+    const first = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+    captureOutput(() => main(['--path', root]));
+    const second = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+
+    // The marked region is regenerated in place; the surrounding bytes are
+    // unchanged. Byte-for-byte equality is the whole point of #86.
+    assert.strictEqual(second, first);
+  });
+});
+
+test('a README without markers is left untouched and the user is told why', () => {
+  withProject((root) => {
+    const readmePath = path.join(root, 'README.md');
+    fs.writeFileSync(readmePath, '# My own README\n\nNothing generated here.\n');
+
+    const { result, stdout } = captureOutput(() => main(['--path', root]));
+
+    assert.strictEqual(result, 0);
+    assert.strictEqual(fs.readFileSync(readmePath, 'utf8'), '# My own README\n\nNothing generated here.\n');
+    assert.match(stdout, /has no <!-- awesome-readme:start --> \/ <!-- awesome-readme:end --> markers, left untouched/);
+    assert.match(stdout, /--force/);
+    // The subdirectory had no README, so it is still created.
+    assert.strictEqual(fs.existsSync(path.join(root, 'src', 'README.md')), true);
+  });
+});
+
+test('--force overwrites a marker-less README entirely', () => {
+  withProject((root) => {
+    const readmePath = path.join(root, 'README.md');
+    fs.writeFileSync(readmePath, '# My own README\n\nGOODBYE-CONTENT\n');
+
+    const { result, stdout } = captureOutput(() => main(['--path', root, '--force']));
+
+    assert.strictEqual(result, 0);
+    const readme = fs.readFileSync(readmePath, 'utf8');
+    assert.ok(!readme.includes('GOODBYE-CONTENT'), '--force should discard the previous content');
+    assert.match(readme, /# demo/);
+    assert.ok(readme.startsWith(MARKER_START));
+    assert.match(stdout, /overwritten in/);
+  });
+});
+
+test('--force also discards content outside the markers', () => {
+  withProject((root) => {
+    captureOutput(() => main(['--path', root]));
+    const readmePath = path.join(root, 'README.md');
+    const generated = fs.readFileSync(readmePath, 'utf8');
+    fs.writeFileSync(readmePath, `CUSTOM-INTRO\n\n${generated}`);
+
+    captureOutput(() => main(['--path', root, '--force']));
+
+    const readme = fs.readFileSync(readmePath, 'utf8');
+    assert.ok(!readme.includes('CUSTOM-INTRO'), '--force is the documented escape hatch and replaces everything');
+  });
+});
+
+test('--if-missing only creates READMEs that do not exist yet', () => {
+  withProject((root) => {
+    const readmePath = path.join(root, 'README.md');
+    fs.writeFileSync(readmePath, '# Keep me\n');
+
+    const { result, stdout } = captureOutput(() => main(['--path', root, '--if-missing']));
+
+    assert.strictEqual(result, 0);
+    assert.strictEqual(fs.readFileSync(readmePath, 'utf8'), '# Keep me\n');
+    assert.match(stdout, /already exists, skipped \(--if-missing\)/);
+    // The missing subdirectory README is still generated.
+    assert.strictEqual(fs.existsSync(path.join(root, 'src', 'README.md')), true);
+  });
+});
+
+test('--if-missing does not update even a marker-bearing README', () => {
+  withProject((root) => {
+    captureOutput(() => main(['--path', root]));
+    const readmePath = path.join(root, 'README.md');
+    // Shrink the generated region so a regeneration would visibly change it.
+    fs.writeFileSync(readmePath, `${MARKER_START}\nPLACEHOLDER\n${MARKER_END}\n`);
+
+    captureOutput(() => main(['--path', root, '--if-missing']));
+
+    assert.strictEqual(fs.readFileSync(readmePath, 'utf8'), `${MARKER_START}\nPLACEHOLDER\n${MARKER_END}\n`);
+  });
+});
+
+test('--force and --if-missing cannot be combined', () => {
+  const stderr = [];
+  const originalError = console.error;
+  console.error = (...args) => stderr.push(args.join(' '));
+  try {
+    const result = main(['--force', '--if-missing']);
+    assert.strictEqual(result, 1);
+    assert.match(stderr.join('\n'), /--force and --if-missing cannot be combined/);
+  } finally {
+    console.error = originalError;
+  }
+});
+
+test('--dry-run reports a merge without writing, and preserves the file', () => {
+  withProject((root) => {
+    captureOutput(() => main(['--path', root]));
+    const readmePath = path.join(root, 'README.md');
+    const before = fs.readFileSync(readmePath, 'utf8');
+
+    const { result, stdout } = captureOutput(() => main(['--path', root, '--dry-run']));
+
+    assert.strictEqual(result, 0);
+    assert.match(stdout, /\[dry-run\] Would update the generated section of/);
+    assert.strictEqual(fs.readFileSync(readmePath, 'utf8'), before);
+  });
+});
+
+test('--dry-run reports the skip for a marker-less README', () => {
+  withProject((root) => {
+    fs.writeFileSync(path.join(root, 'README.md'), '# Mine\n');
+
+    const { stdout } = captureOutput(() => main(['--path', root, '--dry-run']));
+
+    assert.match(stdout, /\[dry-run\] .*left untouched/);
+  });
+});
+
+test('mergeGeneratedContent replaces only the marked region', () => {
+  const existing = `TOP\n${MARKER_START}\nold\n${MARKER_END}\nBOTTOM\n`;
+  const merged = mergeGeneratedContent(existing, 'new');
+
+  assert.strictEqual(merged, `TOP\n${MARKER_START}\nnew\n${MARKER_END}\nBOTTOM\n`);
+});
+
+test('mergeGeneratedContent returns undefined when a marker is missing', () => {
+  assert.strictEqual(mergeGeneratedContent('no markers here', 'new'), undefined);
+  assert.strictEqual(mergeGeneratedContent(`${MARKER_START}\nunclosed`, 'new'), undefined);
+  // An end marker appearing before the start marker is not a usable pair.
+  assert.strictEqual(mergeGeneratedContent(`${MARKER_END}\n${MARKER_START}`, 'new'), undefined);
+});
+
+test('wrapGeneratedContent surrounds the content with both markers', () => {
+  assert.strictEqual(wrapGeneratedContent('body'), `${MARKER_START}\nbody\n${MARKER_END}\n`);
+});
+
+test('writeReadmeFile still accepts a bare mode string and reports its action', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-write-'));
+  try {
+    assert.strictEqual(captureOutput(() => writeReadmeFile(directory, 'body', 'skip')).result, 'skipped');
+    assert.strictEqual(fs.existsSync(path.join(directory, 'README.md')), false);
+
+    assert.strictEqual(captureOutput(() => writeReadmeFile(directory, 'body', 'dry-run')).result, 'created');
+    assert.strictEqual(fs.existsSync(path.join(directory, 'README.md')), false);
+
+    assert.strictEqual(captureOutput(() => writeReadmeFile(directory, 'body', 'write')).result, 'created');
+    assert.strictEqual(captureOutput(() => writeReadmeFile(directory, 'body2', 'write')).result, 'merged');
+    assert.match(fs.readFileSync(path.join(directory, 'README.md'), 'utf8'), /body2/);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #86.

The generator used to fully rewrite README.md every run, which silently destroyed any hand-written content not stored in the config. The new default is non-destructive:

- Generated content is wrapped in <!-- awesome-readme:start --> / <!-- awesome-readme:end --> markers.
- A README with markers has only the marked region regenerated; everything outside the markers is preserved byte-for-byte.
- A README without markers is left untouched with a warning pointing the user at --force.
- --force overwrites the whole file, markers included (the old behaviour, now opt-in).
- --if-missing only creates READMEs for directories that do not have one yet.
- --force and --if-missing are mutually exclusive and rejected up-front.

## Implementation

- `src/writeReadme.ts` is the single place READMEs reach disk. It now returns a `ReadmeWriteAction` so callers and tests can assert on the outcome. The file accepts either a bare `ReadmeWriteMode` (backwards compatible) or a `ReadmeWriteOptions` object carrying `force` / `ifMissing`. The merge logic only replaces the slice between the two markers and returns `undefined` when the pair is missing.
- `src/cli.ts` adds `--force` and `--if-missing`, updates the usage text, and validates that the two flags are not combined.
- `src/index.ts` builds one `rootWriteOptions` and one `subWriteOptions` so the preservation flags apply uniformly across the project tree.
- `src/buildReadme.ts` accepts the options object instead of just a mode.
- `awesome-readme.config.js` documents the markers and the new flags so the example README renders the right guidance for end users.

## Tests

`test/preserveReadme.test.js` (new) covers all of:

- Freshly created READMEs wrap their content in markers
- Hand-written prose above and below the markers survives regeneration
- Regeneration is idempotent (markers preserved, no byte growth)
- Marker-less README is left alone, user is told why, subdirectories still get generated
- --force overwrites a marker-less README entirely
- --force also discards content outside the markers (escape hatch by design)
- --if-missing skips marker-bearing and marker-less READMEs alike
- --force + --if-missing is rejected up-front
- --dry-run reports merges and skips without writing
- Pure helpers: `mergeGeneratedContent`, `wrapGeneratedContent`, and the legacy bare-mode call shape

Two existing tree tests in `test/cli.test.js` pre-create a marker-less README and now pass `--force` to reproduce the old overwrite behaviour; the option-shape assertions pick up `force` / `ifMissing`.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm test` — 61 passed, 0 failed