### PR TITLE
feat: run CI on a Node 20/22/24 matrix and align engines.node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,18 @@ jobs:
   verify:
     name: Lint, typecheck, build & test
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20', '22', '24']
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup Node.js
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "typings": "dist/index.d.ts",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "awesome-readme": "node ./dist/index.js",


### PR DESCRIPTION
Closes #96.

The CI workflow previously ran only on Node 24, which let `engines.node: >=18` drift out of step with reality (Node 18 hit EOL in April 2025) and meant engine-specific breakage wouldn't be caught before publish.

Changes:
- Add a `strategy.matrix.node-version` covering Node 20, 22, and 24, with `fail-fast: false` so a single failing version doesn't cancel the others.
- Bump `engines.node` from `>=18` to `>=20` so the declared range matches the matrix consumers actually install against.

Local verification on Node 20.19.0: `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run build`, and `npm test` (61 tests) all pass. Matrix CI will confirm the same on Node 22 and 24.