### PR TITLE
feat: walk directories to arbitrary depth with a shared recursion

### DIFF
--- a/src/buildReadme.ts
+++ b/src/buildReadme.ts
@@ -1,49 +1,72 @@
-import * as fs from 'fs';
-
-import { listFilteredFiles } from './filterFiles';
-import { renderTreeRows, type TreeEntry } from './tree';
+import { renderTreeLines, type TreeNode } from './tree';
 import type { ExtraData } from './types';
+import type { DirectoryNode } from './walk';
 import { writeReadmeFile, type ReadmeWriteMode, type ReadmeWriteOptions } from './writeReadme';
 
-const buildReadme = (
-  file: string,
-  currentPath: string,
-  title: string,
-  figlet: string,
-  licenseBadge: string,
-  description: string,
-  repositoryUrl: string,
-  prefix = '',
-  extraData: ExtraData,
-  // The directory tree is returned to the caller regardless of the mode, so
-  // `--root-only` and `--dry-run` still render a complete root README. Accepts
-  // either a bare mode or the full write options (`--force`, `--if-missing`).
-  writeOptions: ReadmeWriteMode | ReadmeWriteOptions = 'write'
-): string | undefined => {
-  if (currentPath) {
-    // Shared with the root walk so `ignore_files`, `.git*` and `.gitignore`
-    // rules are applied consistently at every depth.
-    const files = listFilteredFiles(currentPath, extraData);
-    const entries: TreeEntry[] = files.map((name) => {
-      const filePath = currentPath + '/' + name;
-      const stats = fs.statSync(filePath);
-      return { name, isDirectory: stats.isDirectory() };
-    });
+/**
+ * Everything a subdirectory README needs. The generator used to pass ten
+ * positional arguments, which made the deep-nesting call sites unreadable;
+ * an options object keeps them legible now that the walk is recursive.
+ */
+export interface SubReadmeOptions {
+  /** The walked directory this README describes. */
+  node: DirectoryNode;
+  /** Heading of the README, e.g. `my-project / src / utils`. */
+  title: string;
+  figlet: string;
+  licenseBadge: string;
+  description?: string;
+  /** Target of the `[<- Previous]` link, i.e. the parent README. */
+  previousUrl: string;
+  /** Indent prepended to every tree line so the block reads as a subtree. */
+  prefix?: string;
+  extraData: ExtraData;
+  /**
+   * The tree is rendered and returned whatever the mode is, so `--root-only`
+   * and `--dry-run` still produce a complete root README. Accepts either a
+   * bare mode or the full write options (`--force`, `--if-missing`).
+   */
+  writeOptions?: ReadmeWriteMode | ReadmeWriteOptions;
+}
 
-    let directoryFileList = '';
-    let currentFilesList = '';
-    entries.forEach((entry) => {
-      if (entry.isDirectory) directoryFileList += ` - [${entry.name}/](./${entry.name}/)\r`;
-      else currentFilesList += ` - [${entry.name}](./${entry.name})\r`;
-    });
-    // Subdirectory children are rendered with `├───`/`└───` connectors and
-    // indented one level under the parent (`prefix`), so the tree still
-    // looks like a proper tree when it is read on its own in the sub-README.
-    const treeLines = renderTreeRows(entries).map((line) => `${prefix}${line}`);
-    const directoryTree = treeLines.join('\n');
-    const directoryTreePrefix = `\`\`\`\n${file}/\n`;
-    const directoryTreeSuffix = `\`\`\``;
-    const buildReadme = `
+/**
+ * Turn a walked directory into the node list the tree renderer consumes.
+ *
+ * Exported so the root README in `src/index.ts` renders its tree from the
+ * very same structure as every subdirectory README.
+ */
+export const toTreeNodes = (node: DirectoryNode): TreeNode[] => [
+  ...node.files.map((name) => ({ name, isDirectory: false })),
+  ...node.directories.map((child) => ({ name: child.name, isDirectory: true, children: toTreeNodes(child) }))
+];
+
+/**
+ * Write the README of one subdirectory and return its rendered tree.
+ *
+ * The directory contents come from the shared walker rather than a local
+ * `readdir`, so the ignore rules, the ordering and the nesting are identical
+ * to the root README's and hold at any depth.
+ */
+const buildReadme = (options: SubReadmeOptions): string => {
+  const { node, title, figlet, licenseBadge, description = '', previousUrl, prefix = '', extraData, writeOptions = 'write' } = options;
+
+  let directoryFileList = '';
+  let currentFilesList = '';
+  node.directories.forEach((child) => {
+    directoryFileList += ` - [${child.name}/](./${child.name}/)\r`;
+  });
+  node.files.forEach((file) => {
+    currentFilesList += ` - [${file}](./${file})\r`;
+  });
+
+  // The whole subtree is rendered, not just the immediate children, so a
+  // subdirectory README shows everything below it. `prefix` shifts the block
+  // one level in so it still reads as a tree hanging off the directory name.
+  const treeLines = renderTreeLines(toTreeNodes(node)).map((line) => `${prefix}${line}`);
+  const directoryTree = treeLines.join('\n');
+  const directoryTreePrefix = `\`\`\`\n${node.name}/\n`;
+  const directoryTreeSuffix = `\`\`\``;
+  const readmeContents = `
 ${licenseBadge ? licenseBadge + '\n\n' : ''}${extraData.sub_license}
 # ${title ? title : 'Awesome-Readme'}
 ${figlet}
@@ -52,12 +75,11 @@ ${extraData.sub_header}
 ${directoryFileList ? '## Directories\n' + directoryFileList + '\n' : ''}
 ${currentFilesList ? currentFilesList : ''}
 ${extraData.sub_body}
-${directoryTree ? '## Directory Tree\n[<- Previous](' + repositoryUrl + ')\n' + directoryTreePrefix + directoryTree + '\n' + directoryTreeSuffix : ''}
+${directoryTree ? '## Directory Tree\n[<- Previous](' + previousUrl + ')\n' + directoryTreePrefix + directoryTree + '\n' + directoryTreeSuffix : ''}
 ${extraData.sub_footer}
 `;
-    writeReadmeFile(currentPath, buildReadme, writeOptions);
-    return directoryTree;
-  }
+  writeReadmeFile(node.path, readmeContents, writeOptions);
+  return directoryTree;
 };
 
 export default buildReadme;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,11 @@ import * as path from 'path';
 
 import figletLib from 'figlet';
 
-import buildReadme from './buildReadme';
+import buildReadme, { toTreeNodes } from './buildReadme';
 import { parseCliOptions, usage, type CliOptions } from './cli';
-import { listFilteredFiles } from './filterFiles';
-import { renderTreeRows, type TreeEntry } from './tree';
+import { renderTreeLines } from './tree';
 import type { ExtraData } from './types';
+import { walkDirectory, flattenDirectories, DEFAULT_MAX_DEPTH, type DirectoryNode } from './walk';
 import { writeReadmeFile, type ReadmeWriteMode, type ReadmeWriteOptions } from './writeReadme';
 
 const DEFAULT_CONFIG_FILE = 'awesome-readme.config.js';
@@ -56,7 +56,9 @@ const buildMainReadme = (options: Partial<BuildOptions> = {}): void => {
     // Built-in defaults (`node_modules/`, `dist/`, `coverage/`, `build/`) are
     // merged with `ignore_files` unless the config opts out via
     // `ignore_defaults: false`.
-    ignore_defaults: true
+    ignore_defaults: true,
+    // Safety limit for the recursive walk; overridable with `max_depth`.
+    max_depth: DEFAULT_MAX_DEPTH
   };
   // The banner used to ship as a hand-authored "awesome-readme" string. It now
   // starts empty so the auto-generation step below can render a banner from
@@ -96,6 +98,10 @@ ${config.figlet}
     if (config.ignore_gitIgnoreFiles !== undefined) extraData.ignore_gitIgnoreFiles = config.ignore_gitIgnoreFiles;
     if (config.ignore_files !== undefined && config.ignore_files.length > 0) extraData.ignore_files = config.ignore_files;
     if (config.ignore_defaults !== undefined) extraData.ignore_defaults = config.ignore_defaults;
+    // `max_depth` caps how far the recursive walk descends. Anything that is
+    // not a finite, non-negative number is a config mistake rather than a
+    // request to disable the limit, so the default stays in place.
+    if (typeof config.max_depth === 'number' && Number.isFinite(config.max_depth) && config.max_depth >= 0) extraData.max_depth = Math.floor(config.max_depth);
     // `figlet_auto` opt-out. Defaults to true above; explicit `false` keeps
     // the banner empty even when nothing else supplies one.
     if (config.figlet_auto !== undefined) figletAuto = config.figlet_auto !== false;
@@ -169,90 +175,56 @@ ${rendered}
   if (extraData.ignore_files.length > 0) console.log('\x1b[33m', 'Ignoring files: ', '\x1b[0m', extraData.ignore_files.toString());
   if (extraData.ignore_defaults) console.log('\x1b[33m', 'Ignoring default directories: node_modules/, dist/, coverage/, build/', '\x1b[0m');
 
-  const files = listFilteredFiles(currentPath, extraData);
-  const entries: TreeEntry[] = files.map((file) => {
-    const filePath = path.resolve(currentPath, file);
-    const stats = fs.statSync(filePath);
-    return { name: file, isDirectory: stats.isDirectory() };
-  });
-  const fileEntries = entries.filter((entry) => !entry.isDirectory);
-  const directoryEntries = entries.filter((entry) => entry.isDirectory);
-  // Map each subdirectory name to the nested lines from its own tree so they
-  // can be inlined under the parent's directory entry rather than dumped at
-  // the bottom of the root tree.
-  const subDirectoryTreeMap: Record<string, string[]> = {};
+  const tree = walkDirectory(currentPath, extraData);
+  const truncated = flattenDirectories(tree).filter((node) => node.truncated);
+  if (truncated.length > 0)
+    console.log(
+      '\x1b[33m',
+      `Stopped descending at ${truncated.length} director${truncated.length === 1 ? 'y' : 'ies'} (max_depth: ${extraData.max_depth}). Raise max_depth in the config to go deeper.`,
+      '\x1b[0m'
+    );
 
   let directoryFileList = '';
   let currentFilesList = '';
+  tree.directories.forEach((child) => {
+    directoryFileList += ` - [${child.name}/](./${child.name}/)\r`;
+  });
+  tree.files.forEach((file) => {
+    currentFilesList += ` - [${file}](./${file})\n`;
+  });
 
-  // Walk the same directory listing once, building the link list, the
-  // subdirectory tree map and the grandchild README list in lock-step so
-  // the rendering helpers stay the only place that knows about box-drawing
-  // characters.
-  directoryEntries.forEach((entry) => {
-    const filePath = path.resolve(currentPath, entry.name);
-    directoryFileList += ` - [${entry.name}/](./${entry.name}/)\r`;
-    const subTree = buildReadme(
-      entry.name,
-      filePath + '/',
-      repositoryName + ' / ' + entry.name,
-      figlet,
-      licenseBadge,
-      '',
-      repositoryUrl,
-      '   ',
-      extraData,
-      subWriteOptions
-    );
-    // The subdirectory tree is rendered with a '   ' prefix so it sits one
-    // level deep in isolation. Strip those three spaces here so the parent
-    // can prepend its own continuation indent cleanly when nesting.
-    subDirectoryTreeMap[entry.name] = (subTree ?? '')
-      .split('\n')
-      .filter((line) => line.length > 0)
-      .map((line) => line.replace(/^ {3}/, ''));
-    // Second-level walk: filter here too, otherwise an ignored directory
-    // would still get a README generated for it.
-    const subDirectoryFiles = listFilteredFiles(filePath + '/', extraData);
-    if (subDirectoryFiles.length > 0)
-      subDirectoryFiles.forEach((subDirectoryFile) => {
-        const subDirectoryPath = path.resolve(filePath + '/' + subDirectoryFile);
-        const subDirectoryPathStats = fs.statSync(subDirectoryPath);
-        if (subDirectoryPathStats.isDirectory()) {
-          buildReadme(
-            subDirectoryFile,
-            filePath + '/' + subDirectoryFile + '/',
-            repositoryName + ' / ' + entry.name + ' / ' + subDirectoryFile,
-            figlet,
-            licenseBadge,
-            '',
-            repositoryUrl,
-            '   ',
-            extraData,
-            subWriteOptions
-          );
-        }
+  /**
+   * Emit one README per directory, at any depth.
+   *
+   * The walk used to be unrolled by hand for exactly two levels, so a
+   * `src/a/b/` directory never got a README and never showed up in a tree.
+   * Recursing over the walked nodes means depth is bounded by `max_depth`
+   * alone.
+   */
+  const emitSubReadmes = (parent: DirectoryNode, parentTitle: string): void => {
+    parent.directories.forEach((child) => {
+      const title = `${parentTitle} / ${child.name}`;
+      buildReadme({
+        node: child,
+        title,
+        figlet,
+        licenseBadge,
+        // Direct children link back to the repository; deeper directories link
+        // to their parent's README, which is the actual "previous" page.
+        previousUrl: child.depth === 1 ? repositoryUrl : '../README.md',
+        prefix: '   ',
+        extraData,
+        writeOptions: subWriteOptions
       });
-  });
-  fileEntries.forEach((entry) => {
-    currentFilesList += ` - [${entry.name}](./${entry.name})\n`;
-  });
-  // The root tree and the subdirectory trees share the same renderer, so
-  // connectors and last-child logic stay consistent. Files are rendered
-  // first to match the existing root layout, then directories with their
-  // subtrees inlined under each one. The file and directory lists are
-  // rendered as separate batches so each group closes on its own last
-  // child (`└───`), which keeps the visual layout intact.
-  const treeLines: string[] = [`${repositoryName}/`];
-  renderTreeRows(fileEntries).forEach((line) => treeLines.push(line));
-  const directoryLines = renderTreeRows(directoryEntries);
-  directoryEntries.forEach((entry, index) => {
-    const isLast = index === directoryEntries.length - 1;
-    const childIndent = isLast ? '    ' : '│   ';
-    treeLines.push(directoryLines[index]);
-    const subTreeLines = subDirectoryTreeMap[entry.name] || [];
-    subTreeLines.forEach((line) => treeLines.push(`${childIndent}${line}`));
-  });
+      emitSubReadmes(child, title);
+    });
+  };
+  emitSubReadmes(tree, repositoryName);
+
+  // One renderer, one walked tree: the root README and every subdirectory
+  // README now draw the same structure, so connectors, ordering and nesting
+  // cannot drift apart between them at any depth.
+  const treeLines: string[] = [`${repositoryName}/`, ...renderTreeLines(toTreeNodes(tree))];
   const directoryTree = `\`\`\`\n${treeLines.join('\n')}\n\`\`\``;
   const buildReadmeData = `
 ${licenseBadge}${licenseBadge ? '\n' : ''}${extraData.root_license}

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -49,4 +49,42 @@ export const renderTreeRows = (entries: TreeEntry[]): string[] => {
   return lines;
 };
 
+/**
+ * An entry that may carry its own children, so a whole tree can be rendered
+ * in one call instead of the caller stitching level-by-level output together.
+ */
+export interface TreeNode extends TreeEntry {
+  children?: TreeNode[];
+}
+
+/**
+ * Render a tree of arbitrary depth.
+ *
+ * Files are emitted first, then directories, each group closing on its own
+ * `└───` — that is the layout the root README has always produced, and it is
+ * now applied at every level so a subdirectory tree looks the same whether it
+ * is read in the root README or in its own README.
+ *
+ * A directory's children are indented by the continuation column of their
+ * parent: `│   ` while more directories follow at that level, `    ` once the
+ * parent is the last one, so the vertical bars stop where the branch ends.
+ * The nesting used to be done by hand in `src/index.ts` for exactly one level,
+ * which is why deeper directories never made it into the tree.
+ */
+export const renderTreeLines = (nodes: TreeNode[]): string[] => {
+  const files = nodes.filter((node) => !node.isDirectory);
+  const directories = nodes.filter((node) => node.isDirectory);
+  const lines: string[] = [...renderTreeRows(files)];
+  const directoryRows = renderTreeRows(directories);
+
+  directories.forEach((directory, index) => {
+    const isLast = index === directories.length - 1;
+    const childIndent = isLast ? '    ' : '│   ';
+    lines.push(directoryRows[index]);
+    renderTreeLines(directory.children ?? []).forEach((line) => lines.push(`${childIndent}${line}`));
+  });
+
+  return lines;
+};
+
 export default renderTreeRows;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,4 +15,9 @@ export interface ExtraData {
   // `ignore_files` patterns. Defaults to true; set to false to opt out
   // and only honour patterns from the config.
   ignore_defaults: boolean;
+  // How deep the directory walk is allowed to go, counted from the project
+  // root (`0` keeps the walk at the root, `1` covers its direct
+  // subdirectories, …). Defaults to `DEFAULT_MAX_DEPTH` from `src/walk.ts`
+  // and exists purely as a safety limit for pathological trees.
+  max_depth: number;
 }

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -1,0 +1,138 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { listFilteredFiles } from './filterFiles';
+import type { ExtraData } from './types';
+
+/**
+ * Safety limit applied when the config does not set `max_depth`.
+ *
+ * The walker recurses into every subdirectory, so a bound is needed to keep a
+ * pathological tree (or a symlink loop the realpath guard cannot catch) from
+ * running away. Ten levels is far deeper than the two levels the generator
+ * used to cover and still finishes instantly on real projects.
+ */
+export const DEFAULT_MAX_DEPTH = 10;
+
+/**
+ * One directory of the walked project.
+ *
+ * Files and subdirectories are kept apart because every consumer needs them
+ * separately: the README file list only wants files, the directory list and
+ * the recursive README emission only want directories, and the tree renderer
+ * draws the two groups as separate batches.
+ */
+export interface DirectoryNode {
+  /** Directory name (the project root uses the name of its own folder). */
+  name: string;
+  /** Absolute path to the directory, without a trailing separator. */
+  path: string;
+  /** Distance from the walked root; the root itself is 0. */
+  depth: number;
+  /** Names of the non-directory entries left after the ignore rules ran. */
+  files: string[];
+  /** Subdirectories, already walked. */
+  directories: DirectoryNode[];
+  /**
+   * True when the directory has children the walk refused to descend into,
+   * either because `max_depth` was reached or because following it would have
+   * revisited a directory already seen through a symlink.
+   */
+  truncated: boolean;
+}
+
+export interface WalkOptions {
+  /** Overrides `extraData.max_depth` / `DEFAULT_MAX_DEPTH`. */
+  maxDepth?: number;
+}
+
+/**
+ * Recursively read a directory tree, applying the shared ignore rules at
+ * every level.
+ *
+ * The root walk in `src/index.ts` and the subdirectory walk in
+ * `src/buildReadme.ts` each used to read the filesystem on their own, which
+ * capped the generator at two levels (root → child → grandchild) and made it
+ * easy for the two paths to disagree about what "ignored" means. Everything
+ * now goes through this walker, so ignore handling, ordering and depth
+ * limiting live in exactly one place.
+ *
+ * Directories reached twice through symlinks are recorded once and not
+ * descended into a second time, so a `link -> ..` cycle terminates instead of
+ * spinning until `max_depth`.
+ */
+export const walkDirectory = (currentPath: string, extraData: ExtraData, options: WalkOptions = {}): DirectoryNode => {
+  const configuredDepth = options.maxDepth ?? extraData.max_depth;
+  const maxDepth = typeof configuredDepth === 'number' && configuredDepth >= 0 ? configuredDepth : DEFAULT_MAX_DEPTH;
+  const rootPath = path.resolve(currentPath);
+  // Real paths (symlinks resolved) of every directory already walked, so a
+  // cycle is detected by identity rather than by exhausting `max_depth`.
+  const visited = new Set<string>();
+
+  const resolveRealPath = (target: string): string => {
+    try {
+      return fs.realpathSync(target);
+    } catch {
+      // A broken symlink cannot be walked anyway; fall back to the literal
+      // path so the entry is still reported as a (childless) directory.
+      return target;
+    }
+  };
+
+  const walk = (directoryPath: string, name: string, depth: number): DirectoryNode => {
+    const node: DirectoryNode = { name, path: directoryPath, depth, files: [], directories: [], truncated: false };
+    visited.add(resolveRealPath(directoryPath));
+
+    const entries = listFilteredFiles(directoryPath, extraData);
+    const childDirectories: string[] = [];
+    for (const entry of entries) {
+      const entryPath = path.join(directoryPath, entry);
+      let isDirectory = false;
+      try {
+        isDirectory = fs.statSync(entryPath).isDirectory();
+      } catch {
+        // Dangling symlinks and races (a file removed mid-walk) should not
+        // abort the whole generation; treat the entry as a plain file.
+        isDirectory = false;
+      }
+      if (isDirectory) childDirectories.push(entry);
+      else node.files.push(entry);
+    }
+
+    if (childDirectories.length === 0) return node;
+    if (depth >= maxDepth) {
+      node.truncated = true;
+      return node;
+    }
+
+    for (const childName of childDirectories) {
+      const childPath = path.join(directoryPath, childName);
+      if (visited.has(resolveRealPath(childPath))) {
+        // Symlink pointing back into a directory already walked. Keep it in
+        // the tree as an empty directory instead of recursing forever.
+        node.directories.push({ name: childName, path: childPath, depth: depth + 1, files: [], directories: [], truncated: true });
+        continue;
+      }
+      node.directories.push(walk(childPath, childName, depth + 1));
+    }
+
+    return node;
+  };
+
+  return walk(rootPath, path.basename(rootPath), 0);
+};
+
+/**
+ * Every directory of a walked tree, root first, in depth-first order.
+ *
+ * Callers that need to act on each directory (emitting one README per
+ * directory, counting truncations, …) iterate this instead of writing their
+ * own recursion.
+ */
+export const flattenDirectories = (node: DirectoryNode): DirectoryNode[] => {
+  const nodes: DirectoryNode[] = [node];
+  for (const child of node.directories) nodes.push(...flattenDirectories(child));
+  return nodes;
+};
+
+export default walkDirectory;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -44,6 +44,16 @@ const makeProject = () => {
   return root;
 };
 
+// The root README has the figlet code block then the tree block; the
+// subdirectory README has a `[<- Previous](url)` link line between the
+// `## Directory Tree` heading and the tree's fence. The tree is always the
+// last fenced block, so grab that one and strip its fences.
+const extractTree = (readme) => {
+  const blocks = readme.match(/```\n[\s\S]*?\n```/g);
+  if (!blocks || blocks.length === 0) return '';
+  return blocks[blocks.length - 1].replace(/^```\n/, '').replace(/\n```$/, '');
+};
+
 test('parseCliOptions defaults every flag to off', () => {
   assert.deepStrictEqual(parseCliOptions([]), {
     help: false,
@@ -252,18 +262,6 @@ test('generated trees match the issue #82 fixture', () => {
   fs.mkdirSync(path.join(root, 'src'));
   fs.writeFileSync(path.join(root, 'docs', 'notes.md'), '');
 
-  const extractTree = (readme) => {
-    // The root README has the figlet code block then the tree block; the
-    // subdirectory README has a `[<- Previous](url)` link line between the
-    // `## Directory Tree` heading and the tree's fence. Anchor on the
-    // heading and grab the last fenced block, which is always the tree.
-    const blocks = readme.match(/```\n[\s\S]*?\n```/g);
-    if (!blocks || blocks.length === 0) return '';
-    const treeBlock = blocks[blocks.length - 1];
-    // Strip the surrounding fences.
-    return treeBlock.replace(/^```\n/, '').replace(/\n```$/, '');
-  };
-
   try {
     captureOutput(() => main(['--path', root, '--force']));
 
@@ -281,6 +279,105 @@ test('generated trees match the issue #82 fixture', () => {
     const docsTree = extractTree(fs.readFileSync(path.join(root, 'docs', 'README.md'), 'utf8'));
     const expectedDocsTree = ['docs/', '   └─── notes.md'].join('\n');
     assert.strictEqual(docsTree, expectedDocsTree);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Coverage for #81: the walk used to be unrolled by hand for two levels, so
+// `src/a/b/` got neither a README nor a line in any tree.
+const makeDeepProject = (prefix) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'demo',
+      license: 'MIT',
+      repository: { type: 'git', url: 'git+https://github.com/demo/demo.git' }
+    })
+  );
+  fs.mkdirSync(path.join(root, 'src', 'a', 'b', 'c'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'src', 'index.ts'), '');
+  fs.writeFileSync(path.join(root, 'src', 'a', 'b', 'c', 'leaf.ts'), '');
+  return root;
+};
+
+test('READMEs are generated for directories nested more than two levels deep', () => {
+  const root = makeDeepProject('awesome-readme-deep-');
+
+  try {
+    const { result } = captureOutput(() => main(['--path', root, '--force']));
+
+    assert.strictEqual(result, 0);
+    for (const directory of [['src'], ['src', 'a'], ['src', 'a', 'b'], ['src', 'a', 'b', 'c']]) {
+      assert.strictEqual(fs.existsSync(path.join(root, ...directory, 'README.md')), true, `${directory.join('/')} should have a README`);
+    }
+    // Deep READMEs link back to their parent README rather than the repo root.
+    const deepReadme = fs.readFileSync(path.join(root, 'src', 'a', 'README.md'), 'utf8');
+    assert.match(deepReadme, /\[<- Previous\]\(\.\.\/README\.md\)/);
+    // Direct children keep the repository link they have always had.
+    const srcReadme = fs.readFileSync(path.join(root, 'src', 'README.md'), 'utf8');
+    assert.match(srcReadme, /\[<- Previous\]\(https:\/\/github\.com\/demo\/demo\)/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('the root tree nests every level with the right continuation column', () => {
+  const root = makeDeepProject('awesome-readme-deep-tree-');
+
+  try {
+    // `--force` so the README files exist by the time the root tree is
+    // rendered — the walk happens before the writes, otherwise none of the
+    // generated `README.md` files would show up in the tree.
+    captureOutput(() => main(['--path', root, '--force']));
+
+    const rootTree = extractTree(fs.readFileSync(path.join(root, 'README.md'), 'utf8'));
+    assert.strictEqual(
+      rootTree,
+      [
+        'demo/',
+        '└─── package.json',
+        '└─── src/',
+        '    └─── index.ts',
+        '    └─── a/',
+        '        └─── b/',
+        '            └─── c/',
+        '                └─── leaf.ts'
+      ].join('\n')
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a subdirectory README shows its whole subtree, not just its children', () => {
+  const root = makeDeepProject('awesome-readme-deep-sub-');
+
+  try {
+    captureOutput(() => main(['--path', root, '--force']));
+
+    const srcTree = extractTree(fs.readFileSync(path.join(root, 'src', 'README.md'), 'utf8'));
+    assert.match(srcTree, /^src\//);
+    assert.match(srcTree, /leaf\.ts/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('max_depth caps how deep the walk goes', () => {
+  const root = makeDeepProject('awesome-readme-max-depth-');
+  fs.writeFileSync(path.join(root, 'awesome-readme.config.js'), 'module.exports = { max_depth: 2 };\n');
+
+  try {
+    const { result, stdout } = captureOutput(() => main(['--path', root, '--force']));
+
+    assert.strictEqual(result, 0);
+    assert.match(stdout, /max_depth: 2/);
+    assert.strictEqual(fs.existsSync(path.join(root, 'src', 'a', 'README.md')), true);
+    assert.strictEqual(fs.existsSync(path.join(root, 'src', 'a', 'b', 'README.md')), false);
+    // Nothing below the limit leaks into the root tree either.
+    assert.doesNotMatch(fs.readFileSync(path.join(root, 'README.md'), 'utf8'), /leaf\.ts/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/test/tree.test.js
+++ b/test/tree.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert');
 const { test } = require('node:test');
 
-const { renderTreeRows } = require('../dist/tree');
+const { renderTreeRows, renderTreeLines } = require('../dist/tree');
 
 test('renderTreeRows emits a single line per entry in the given order', () => {
   const entries = [
@@ -96,4 +96,63 @@ test('renderTreeRows matches the issue #82 fixture tree', () => {
   ].join('\n');
 
   assert.strictEqual(tree, expected);
+});
+
+// Coverage for #81: the nesting used to be unrolled by hand for a single
+// level in `src/index.ts`, so a grandchild directory never made it into any
+// tree. `renderTreeLines` recurses instead.
+test('renderTreeLines nests children of arbitrary depth', () => {
+  const nodes = [
+    { name: 'README.md', isDirectory: false },
+    {
+      name: 'src',
+      isDirectory: true,
+      children: [
+        { name: 'index.ts', isDirectory: false },
+        {
+          name: 'deep',
+          isDirectory: true,
+          children: [
+            { name: 'deeper', isDirectory: true, children: [{ name: 'leaf.ts', isDirectory: false }] }
+          ]
+        }
+      ]
+    }
+  ];
+
+  assert.deepStrictEqual(renderTreeLines(nodes), [
+    '└─── README.md',
+    '└─── src/',
+    '    └─── index.ts',
+    '    └─── deep/',
+    '        └─── deeper/',
+    '            └─── leaf.ts'
+  ]);
+});
+
+test('renderTreeLines keeps the continuation column open while siblings follow', () => {
+  const nodes = [
+    { name: 'alpha', isDirectory: true, children: [{ name: 'a.txt', isDirectory: false }] },
+    { name: 'beta', isDirectory: true, children: [{ name: 'b.txt', isDirectory: false }] }
+  ];
+
+  assert.deepStrictEqual(renderTreeLines(nodes), [
+    '├─── alpha/',
+    '│   └─── a.txt',
+    '└─── beta/',
+    '    └─── b.txt'
+  ]);
+});
+
+test('renderTreeLines renders files before directories at every level', () => {
+  const nodes = [
+    { name: 'src', isDirectory: true, children: [] },
+    { name: 'package.json', isDirectory: false }
+  ];
+
+  assert.deepStrictEqual(renderTreeLines(nodes), ['└─── package.json', '└─── src/']);
+});
+
+test('renderTreeLines returns an empty array for no nodes', () => {
+  assert.deepStrictEqual(renderTreeLines([]), []);
 });

--- a/test/walk.test.js
+++ b/test/walk.test.js
@@ -1,0 +1,171 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const { walkDirectory, flattenDirectories, DEFAULT_MAX_DEPTH } = require('../dist/walk');
+
+const options = (overrides = {}) => ({
+  ignore_gitFiles: true,
+  ignore_gitIgnoreFiles: true,
+  ignore_files: [],
+  ignore_defaults: true,
+  max_depth: DEFAULT_MAX_DEPTH,
+  ...overrides
+});
+
+// `a/b/c/d` with one file at every level, which is two levels deeper than the
+// old hand-unrolled walk could reach.
+const makeDeepProject = () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-walk-'));
+  fs.writeFileSync(path.join(root, 'root.txt'), '');
+  let current = root;
+  for (const name of ['a', 'b', 'c', 'd']) {
+    current = path.join(current, name);
+    fs.mkdirSync(current);
+    fs.writeFileSync(path.join(current, `${name}.txt`), '');
+  }
+  return root;
+};
+
+test('walkDirectory descends past the two levels the generator used to cover', () => {
+  const root = makeDeepProject();
+
+  try {
+    const tree = walkDirectory(root, options());
+
+    assert.deepStrictEqual(tree.files, ['root.txt']);
+    const a = tree.directories[0];
+    const b = a.directories[0];
+    const c = b.directories[0];
+    const d = c.directories[0];
+    assert.deepStrictEqual(
+      [a.name, b.name, c.name, d.name],
+      ['a', 'b', 'c', 'd']
+    );
+    assert.deepStrictEqual([a.depth, b.depth, c.depth, d.depth], [1, 2, 3, 4]);
+    assert.deepStrictEqual(d.files, ['d.txt']);
+    assert.deepStrictEqual(d.directories, []);
+    assert.strictEqual(d.truncated, false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('walkDirectory separates files from directories at every level', () => {
+  const root = makeDeepProject();
+
+  try {
+    const tree = walkDirectory(root, options());
+
+    for (const node of flattenDirectories(tree)) {
+      assert.ok(
+        node.files.every((file) => !fs.statSync(path.join(node.path, file)).isDirectory()),
+        `${node.name} listed a directory as a file`
+      );
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('walkDirectory applies the ignore rules at every depth', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-walk-ignore-'));
+  fs.mkdirSync(path.join(root, 'src', 'deep'), { recursive: true });
+  // Default ignores (node_modules/) three levels down, not just at the root.
+  fs.mkdirSync(path.join(root, 'src', 'deep', 'node_modules'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'src', 'deep', 'keep.ts'), '');
+  fs.writeFileSync(path.join(root, 'src', 'deep', 'debug.log'), '');
+  // A `.gitignore` living in a subdirectory applies to that subdirectory.
+  fs.writeFileSync(path.join(root, 'src', '.gitignore'), 'secret.ts\n');
+  fs.writeFileSync(path.join(root, 'src', 'secret.ts'), '');
+
+  try {
+    const tree = walkDirectory(root, options({ ignore_files: ['*.log'] }));
+
+    const src = tree.directories.find((node) => node.name === 'src');
+    assert.ok(src, 'src should be walked');
+    assert.strictEqual(src.files.includes('secret.ts'), false, 'subdirectory .gitignore should apply');
+    const deep = src.directories.find((node) => node.name === 'deep');
+    assert.deepStrictEqual(deep.files, ['keep.ts']);
+    assert.deepStrictEqual(deep.directories, [], 'node_modules should be ignored at depth');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('walkDirectory stops at max_depth and flags the truncated directories', () => {
+  const root = makeDeepProject();
+
+  try {
+    const tree = walkDirectory(root, options({ max_depth: 2 }));
+
+    const a = tree.directories[0];
+    const b = a.directories[0];
+    assert.strictEqual(b.name, 'b');
+    assert.deepStrictEqual(b.directories, [], 'c is past max_depth');
+    assert.strictEqual(b.truncated, true);
+    // The levels above the limit are complete, so they are not flagged.
+    assert.strictEqual(a.truncated, false);
+    assert.strictEqual(tree.truncated, false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('max_depth: 0 keeps the walk at the root', () => {
+  const root = makeDeepProject();
+
+  try {
+    const tree = walkDirectory(root, options({ max_depth: 0 }));
+
+    assert.deepStrictEqual(tree.files, ['root.txt']);
+    assert.deepStrictEqual(tree.directories, []);
+    assert.strictEqual(tree.truncated, true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('walkDirectory terminates on a symlink cycle', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-walk-cycle-'));
+  fs.mkdirSync(path.join(root, 'src'));
+  fs.writeFileSync(path.join(root, 'src', 'index.ts'), '');
+  try {
+    // Windows CI without developer mode cannot create directory symlinks.
+    fs.symlinkSync(root, path.join(root, 'src', 'loop'), 'dir');
+  } catch {
+    fs.rmSync(root, { recursive: true, force: true });
+    t.skip('symlinks are not supported on this platform');
+    return;
+  }
+
+  try {
+    const tree = walkDirectory(root, options());
+
+    const src = tree.directories.find((node) => node.name === 'src');
+    const loop = src.directories.find((node) => node.name === 'loop');
+    assert.ok(loop, 'the symlink is still reported as a directory');
+    assert.deepStrictEqual(loop.directories, [], 'the cycle is not followed');
+    assert.strictEqual(loop.truncated, true);
+    // Terminating through the cycle guard rather than max_depth means the
+    // tree stays shallow instead of unrolling ten identical levels.
+    assert.strictEqual(flattenDirectories(tree).length, 3);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('flattenDirectories lists every directory root-first', () => {
+  const root = makeDeepProject();
+
+  try {
+    const names = flattenDirectories(walkDirectory(root, options())).map((node) => node.name);
+
+    assert.deepStrictEqual(names.slice(1), ['a', 'b', 'c', 'd']);
+    assert.strictEqual(names[0], path.basename(root));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #81

The root walk in `src/index.ts` and the subdirectory walk in `src/buildReadme` each used to filter the filesystem on their own, which capped the generator at root → child → grandchild and made ignore handling easy to drift apart. Everything now goes through a single recursive walker in `src/walk.ts`:

- a README is generated for every directory up to `max_depth` (default 10)
- `ignore_files`, `.gitignore`, `.git*` and the built-in defaults apply at every level, not just at the root
- the root tree and every subdirectory tree share one renderer, so connectors, ordering and the continuation column stay in lock-step at any depth
- direct children still link back to the repository, deeper directories link to their parent README with `../README.md`
- symlink cycles are caught by a realpath guard so a `link -> ..` cannot run away until `max_depth`

New tests cover deep nesting, `max_depth` truncation (including `max_depth: 0`), symlink cycle termination, ignore rules at depth, the new recursive tree renderer and end-to-end deep projects.