### PR TITLE
feat: add checked-in example projects demonstrating usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- awesome-readme:start -->
 
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 [![npm version](https://badge.fury.io/js/awesome-readme.svg)](https://badge.fury.io/js/awesome-readme)
@@ -44,7 +45,16 @@ Options:
   -p, --path <dir>      Project root to generate READMEs for (default: current directory)
   -c, --config <file>   Path to the config file (default: <path>/awesome-readme.config.js)
       --root-only       Only write the root README, skip subdirectory READMEs
+      --force           Overwrite existing READMEs entirely, discarding their content
+      --if-missing      Only create READMEs for directories that do not have one
 ```
+
+Existing READMEs are never clobbered: generated content lives between
+`<!-- awesome-readme:start -->` and `<!-- awesome-readme:end -->` markers
+and only that region is regenerated on the next run. A README without markers
+is left untouched unless `--force` is passed. To regenerate part of a
+hand-written README, wrap the section you want the tool to own with the two
+markers.
 
 Preview the output before touching your files:
 
@@ -58,8 +68,19 @@ Generate for another project, with a config living elsewhere:
 npx awesome-readme --path ./packages/core --config ./readme.config.js
 ```
 
+Add the markers to a hand-written README to opt into partial regeneration:
+
+```
+<!-- awesome-readme:start -->
+<!-- awesome-readme:end -->
+```
+
+Fill the gap with anything you want the tool to own (a tree, a badge list, an
+auto-generated file index, etc.) and the next run will refresh that block
+without touching the rest of the file.
+
 ## Directories
- - [.vscode/](./.vscode/) - [src/](./src/) - [test/](./test/)
+ - [.vscode/](./.vscode/) - [examples/](./examples/) - [src/](./src/) - [test/](./test/)
 
  - [.npmignore](./.npmignore)
  - [.prettierrc](./.prettierrc)
@@ -140,6 +161,34 @@ awesome-readme/
 │   ├─── README.md
 │   ├─── extensions.json
 │   └─── settings.json
+├─── examples/
+│   └─── README.md
+│   ├─── minimal/
+│   │   ├─── README.md
+│   │   └─── package.json
+│   │   └─── src/
+│   │       ├─── README.md
+│   │       └─── index.js
+│   ├─── nested/
+│   │   ├─── README.md
+│   │   └─── package.json
+│   │   ├─── src/
+│   │   │   ├─── README.md
+│   │   │   └─── index.js
+│   │   │   └─── lib/
+│   │   │       ├─── README.md
+│   │   │       ├─── format.js
+│   │   │       └─── math.js
+│   │   └─── test/
+│   │       ├─── README.md
+│   │       └─── smoke.test.js
+│   └─── with-config/
+│       ├─── README.md
+│       ├─── awesome-readme.config.js
+│       └─── package.json
+│       └─── src/
+│           ├─── README.md
+│           └─── index.js
 ├─── src/
 │   ├─── README.md
 │   ├─── buildReadme.ts
@@ -148,11 +197,175 @@ awesome-readme/
 │   ├─── index.ts
 │   ├─── tree.ts
 │   ├─── types.ts
+│   ├─── walk.ts
 │   └─── writeReadme.ts
 └─── test/
     ├─── README.md
     ├─── cli.test.js
     ├─── filterFiles.test.js
-    └─── tree.test.js
+    ├─── preserveReadme.test.js
+    ├─── tree.test.js
+    └─── walk.test.js
 ```
 ## Don't hesitate to contribute to this project.
+
+<!-- awesome-readme:end -->` markers
+and only that region is regenerated on the next run. A README without markers
+is left untouched unless `--force` is passed. To regenerate part of a
+hand-written README, wrap the section you want the tool to own with the two
+markers.
+
+Preview the output before touching your files:
+
+```
+npx awesome-readme --dry-run
+```
+
+Generate for another project, with a config living elsewhere:
+
+```
+npx awesome-readme --path ./packages/core --config ./readme.config.js
+```
+
+Add the markers to a hand-written README to opt into partial regeneration:
+
+```
+<!-- awesome-readme:start -->
+<!-- awesome-readme:end -->
+```
+
+Fill the gap with anything you want the tool to own (a tree, a badge list, an
+auto-generated file index, etc.) and the next run will refresh that block
+without touching the rest of the file.
+
+## Directories
+ - [.vscode/](./.vscode/) - [examples/](./examples/) - [src/](./src/) - [test/](./test/)
+
+ - [.npmignore](./.npmignore)
+ - [.prettierrc](./.prettierrc)
+ - [CONTRIBUTING.md](./CONTRIBUTING.md)
+ - [LICENSE](./LICENSE)
+ - [README.md](./README.md)
+ - [awesome-readme.config.js](./awesome-readme.config.js)
+ - [eslint.config.js](./eslint.config.js)
+ - [package-lock.json](./package-lock.json)
+ - [package.json](./package.json)
+ - [tsconfig.json](./tsconfig.json)
+
+
+
+## Configuration with awesome-readme.config.js
+
+```
+module.exports = {
+    // Set figlet_text to a plain string and the tool will render it with the
+    // figlet package at build time (no need to hand-author ASCII art). Use
+    // figlet_font to pick a different font (defaults to "Standard"). Leave the
+    // pre-rendered figlet below in place if you want to use that instead.
+    // figlet_text: 'awesome-readme',
+    // figlet_font: 'Standard',
+    // By default a banner is auto-generated from `package.json` `name` when
+    // neither `figlet` nor `figlet_text` is set. Set `figlet_auto` to
+    // false to keep the banner blank, or to true to force auto-generation
+    // even when `figlet_text` is unset.
+    // figlet_auto: true,
+    figlet: `
+    .d8b.  db   d8b   db d88888b .d8888.  .d88b.  .88b  d88. d88888b        d8888b. d88888b  .d8b.  d8888b. .88b  d88. d88888b
+    d8' '8b 88   I8I   88 88'     88'  YP .8P  Y8. 88'YbdP'88 88'            88  '8D 88'     d8' '8b 88  '8D 88'YbdP'88 88'
+    88ooo88 88   I8I   88 88ooooo '8bo.   88    88 88  88  88 88ooooo        88oobY' 88ooooo 88ooo88 88   88 88  88  88 88ooooo
+    88~~~88 Y8   I8I   88 88~~~~~   'Y8b. 88    88 88  88  88 88~~~~~ C8888D 88'8b   88~~~~~ 88~~~88 88   88 88  88  88 88~~~~~
+    88   88 '8b d8'8b d8' 88.     db   8D '8b  d8' 88  88  88 88.            88 '88. 88.     88   88 88  .8D 88  88  88 88.
+    YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD Y88888P YP   YP Y8888D' YP  YP  YP Y88888P`,
+    root_license: `[![npm version](https://badge.fury.io/js/awesome-readme.svg)](https://badge.fury.io/js/awesome-readme)`,
+    root_header: `
+    ## Install Awesome-Readme
+    ```
+    npm i awesome-readme
+    ```
+    ## Use Awesome-Readme
+    ```
+    npx awesome-readme
+    ````,
+    root_body: `## Configuration with awesome-readme.config.js`,
+    root_footer: `## Don't hesitate to contribute to this project.`,
+    sub_license: `[![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)`,
+    sub_header: `## About this directory`,
+    sub_body: `This directory is part of the awesome-readme project.`,
+    sub_footer: `## Don't hesitate to contribute to this project.`,
+    ignore_gitFiles: true,
+    ignore_gitIgnoreFiles: true,
+    // `ignore_files` accepts gitignore-style globs (`*.log`, `dist/`). On top of
+    // what is listed here, a small set of defaults (node_modules/, dist/,
+    // coverage/, build/) is merged in automatically; set `ignore_defaults` to
+    // false to opt out.
+    ignore_files: ['.prettierignore'],
+    ignore_defaults: true
+}
+```
+
+## Directory Tree
+```
+awesome-readme/
+├─── .npmignore
+├─── .prettierrc
+├─── CONTRIBUTING.md
+├─── LICENSE
+├─── README.md
+├─── awesome-readme.config.js
+├─── eslint.config.js
+├─── package-lock.json
+├─── package.json
+└─── tsconfig.json
+├─── .vscode/
+│   ├─── README.md
+│   ├─── extensions.json
+│   └─── settings.json
+├─── examples/
+│   └─── README.md
+│   ├─── minimal/
+│   │   ├─── README.md
+│   │   └─── package.json
+│   │   └─── src/
+│   │       ├─── README.md
+│   │       └─── index.js
+│   ├─── nested/
+│   │   ├─── README.md
+│   │   └─── package.json
+│   │   ├─── src/
+│   │   │   ├─── README.md
+│   │   │   └─── index.js
+│   │   │   └─── lib/
+│   │   │       ├─── README.md
+│   │   │       ├─── format.js
+│   │   │       └─── math.js
+│   │   └─── test/
+│   │       ├─── README.md
+│   │       └─── smoke.test.js
+│   └─── with-config/
+│       ├─── README.md
+│       ├─── awesome-readme.config.js
+│       └─── package.json
+│       └─── src/
+│           ├─── README.md
+│           └─── index.js
+├─── src/
+│   ├─── README.md
+│   ├─── buildReadme.ts
+│   ├─── cli.ts
+│   ├─── filterFiles.ts
+│   ├─── index.ts
+│   ├─── tree.ts
+│   ├─── types.ts
+│   ├─── walk.ts
+│   └─── writeReadme.ts
+└─── test/
+    ├─── README.md
+    ├─── cli.test.js
+    ├─── filterFiles.test.js
+    ├─── preserveReadme.test.js
+    ├─── tree.test.js
+    └─── walk.test.js
+```
+## Don't hesitate to contribute to this project.
+
+<!-- awesome-readme:end -->

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,112 @@
+# Examples
+
+Small, self-contained projects you can point `awesome-readme` at to see how
+the generator behaves under different layouts and configurations.
+
+Each example ships with a pre-generated `README.md` so the output can be
+inspected on GitHub without running anything. To regenerate from scratch
+from the repository root:
+
+```
+npm run build
+npx awesome-readme --path examples/<name> --force
+```
+
+Add `--dry-run` to preview what would be written without touching the files.
+
+## `minimal/`
+
+The smallest possible input: one `package.json` and one source file under
+`src/`. Demonstrates the zero-config path — the figlet banner is
+auto-generated from `package.json` `name` and the root tree shows both the
+file and the directory.
+
+## `nested/`
+
+A monorepo-style layout with `src/lib/` two levels deep and a parallel
+`test/` directory. Exercises the recursive directory walk: every level gets
+its own README and the root tree nests the subtrees under their parent
+directories.
+
+## `with-config/`
+
+Shows how an `awesome-readme.config.js` reshapes the generated README:
+
+- `figlet_text` + `figlet_font` instead of the auto-generated banner
+- Custom `root_header` and `root_footer`
+- An `ignore_files` glob (`build/`) that hides the build output without
+  needing a `.gitignore`
+
+Run it with the explicit `--config` flag if you want to point at a config
+living elsewhere:
+
+```
+npx awesome-readme --path examples/with-config --config examples/with-config/awesome-readme.config.js
+```
+
+## Keeping the generated files in sync
+
+The checked-in `README.md` files are produced by the generator, not
+maintained by hand. Feel free to delete them and regenerate when the
+renderer changes — diffs in the output are the whole point of having
+checked-in examples. The hand-written intro above lives outside the
+generated markers so it survives regeneration.
+
+<!-- awesome-readme:start -->
+
+[![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
+
+[![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
+# awesome-readme / examples
+
+```
+
+ .d8b.  db   d8b   db d88888b .d8888.  .d88b.  .88b  d88. d88888b        d8888b. d88888b  .d8b.  d8888b. .88b  d88. d88888b
+d8' '8b 88   I8I   88 88'     88'  YP .8P  Y8. 88'YbdP'88 88'            88  '8D 88'     d8' '8b 88  '8D 88'YbdP'88 88'
+88ooo88 88   I8I   88 88ooooo '8bo.   88    88 88  88  88 88ooooo        88oobY' 88ooooo 88ooo88 88   88 88  88  88 88ooooo
+88~~~88 Y8   I8I   88 88~~~~~   'Y8b. 88    88 88  88  88 88~~~~~ C8888D 88'8b   88~~~~~ 88~~~88 88   88 88  88  88 88~~~~~
+88   88 '8b d8'8b d8' 88.     db   8D '8b  d8' 88  88  88 88.            88 '88. 88.     88   88 88  .8D 88  88  88 88.
+YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD Y88888P YP   YP Y8888D' YP  YP  YP Y88888P 
+```
+
+## About this directory
+## Directories
+ - [minimal/](./minimal/) - [nested/](./nested/) - [with-config/](./with-config/)
+
+ - [README.md](./README.md)
+This directory is part of the awesome-readme project.
+## Directory Tree
+[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+```
+examples/
+   └─── README.md
+   ├─── minimal/
+   │   ├─── README.md
+   │   └─── package.json
+   │   └─── src/
+   │       ├─── README.md
+   │       └─── index.js
+   ├─── nested/
+   │   ├─── README.md
+   │   └─── package.json
+   │   ├─── src/
+   │   │   ├─── README.md
+   │   │   └─── index.js
+   │   │   └─── lib/
+   │   │       ├─── README.md
+   │   │       ├─── format.js
+   │   │       └─── math.js
+   │   └─── test/
+   │       ├─── README.md
+   │       └─── smoke.test.js
+   └─── with-config/
+       ├─── README.md
+       ├─── awesome-readme.config.js
+       └─── package.json
+       └─── src/
+           ├─── README.md
+           └─── index.js
+```
+## Don't hesitate to contribute to this project.
+
+<!-- awesome-readme:end -->

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / examples / minimal
 
 ```
 
@@ -16,22 +16,20 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 ```
 
 ## About this directory
+## Directories
+ - [src/](./src/)
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [package.json](./package.json)
 This directory is part of the awesome-readme project.
 ## Directory Tree
-[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+[<- Previous](../README.md)
 ```
-src/
+minimal/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   └─── package.json
+   └─── src/
+       ├─── README.md
+       └─── index.js
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "minimal",
+  "version": "0.1.0",
+  "description": "Smallest possible awesome-readme example: just a package.json and one source file.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/example/minimal.git"
+  }
+}

--- a/examples/minimal/src/README.md
+++ b/examples/minimal/src/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / examples / minimal / src
 
 ```
 
@@ -17,21 +17,14 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [index.js](./index.js)
 This directory is part of the awesome-readme project.
 ## Directory Tree
-[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+[<- Previous](../README.md)
 ```
 src/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   └─── index.js
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/minimal/src/index.js
+++ b/examples/minimal/src/index.js
@@ -1,0 +1,4 @@
+// Single source file so the generated tree has something interesting to draw.
+// Run `npx awesome-readme --path examples/minimal` from the repo root to
+// regenerate the README.
+module.exports = { greeting: 'hello from minimal' };

--- a/examples/nested/README.md
+++ b/examples/nested/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / examples / nested
 
 ```
 
@@ -16,22 +16,27 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 ```
 
 ## About this directory
+## Directories
+ - [src/](./src/) - [test/](./test/)
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [package.json](./package.json)
 This directory is part of the awesome-readme project.
 ## Directory Tree
-[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+[<- Previous](../README.md)
 ```
-src/
+nested/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   └─── package.json
+   ├─── src/
+   │   ├─── README.md
+   │   └─── index.js
+   │   └─── lib/
+   │       ├─── README.md
+   │       ├─── format.js
+   │       └─── math.js
+   └─── test/
+       ├─── README.md
+       └─── smoke.test.js
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/nested/package.json
+++ b/examples/nested/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "nested",
+  "version": "0.1.0",
+  "description": "Monorepo-style layout with nested source and test directories — exercises the recursive walk.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/example/nested.git"
+  }
+}

--- a/examples/nested/src/README.md
+++ b/examples/nested/src/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / examples / nested / src
 
 ```
 
@@ -16,22 +16,21 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 ```
 
 ## About this directory
+## Directories
+ - [lib/](./lib/)
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [index.js](./index.js)
 This directory is part of the awesome-readme project.
 ## Directory Tree
-[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+[<- Previous](../README.md)
 ```
 src/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   └─── index.js
+   └─── lib/
+       ├─── README.md
+       ├─── format.js
+       └─── math.js
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/nested/src/index.js
+++ b/examples/nested/src/index.js
@@ -1,0 +1,7 @@
+// Top-level entry point for the nested example. Re-exports the helpers that
+// live deeper in the tree so the README's auto-generated file list stays
+// short and readable.
+const { add } = require('./lib/math');
+const { format } = require('./lib/format');
+
+module.exports = { add, format };

--- a/examples/nested/src/lib/README.md
+++ b/examples/nested/src/lib/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / examples / nested / src / lib
 
 ```
 
@@ -17,21 +17,15 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [format.js](./format.js) - [math.js](./math.js)
 This directory is part of the awesome-readme project.
 ## Directory Tree
-[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+[<- Previous](../README.md)
 ```
-src/
+lib/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   ├─── format.js
+   └─── math.js
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/nested/src/lib/format.js
+++ b/examples/nested/src/lib/format.js
@@ -1,0 +1,5 @@
+// Tiny string formatter. The point is to give the nested example more than
+// one leaf under `lib/`, so the subdirectory tree actually has branches.
+const format = (label, value) => `${label}: ${value}`;
+
+module.exports = { format };

--- a/examples/nested/src/lib/math.js
+++ b/examples/nested/src/lib/math.js
@@ -1,0 +1,5 @@
+// Small utility used by the nested example. Living two directories deep keeps
+// the recursive walk honest when the README is regenerated.
+const add = (a, b) => a + b;
+
+module.exports = { add };

--- a/examples/nested/test/README.md
+++ b/examples/nested/test/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / examples / nested / test
 
 ```
 
@@ -17,21 +17,14 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [smoke.test.js](./smoke.test.js)
 This directory is part of the awesome-readme project.
 ## Directory Tree
-[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+[<- Previous](../README.md)
 ```
-src/
+test/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   └─── smoke.test.js
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/nested/test/smoke.test.js
+++ b/examples/nested/test/smoke.test.js
@@ -1,0 +1,6 @@
+// Minimal test that the nested example ships with. Exists so the generated
+// tree shows a `test/` directory alongside `src/` and `lib/`.
+const assert = require('node:assert');
+const { add } = require('../src/lib/math');
+
+assert.strictEqual(add(1, 2), 3);

--- a/examples/with-config/README.md
+++ b/examples/with-config/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / examples / with-config
 
 ```
 
@@ -16,22 +16,21 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 ```
 
 ## About this directory
+## Directories
+ - [src/](./src/)
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [awesome-readme.config.js](./awesome-readme.config.js) - [package.json](./package.json)
 This directory is part of the awesome-readme project.
 ## Directory Tree
-[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+[<- Previous](../README.md)
 ```
-src/
+with-config/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   ├─── awesome-readme.config.js
+   └─── package.json
+   └─── src/
+       ├─── README.md
+       └─── index.js
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/with-config/awesome-readme.config.js
+++ b/examples/with-config/awesome-readme.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  // Skip the auto-generated figlet banner; `figlet_text` is rendered at build
+  // time so the artwork stays in sync with the chosen font.
+  figlet_auto: false,
+  figlet_text: 'with-config',
+  figlet_font: 'Standard',
+  // Hand-written sections for the root README. Subdirectory READMEs keep the
+  // global `sub_*` defaults below.
+  root_header: '\n## What this example shows\n\nA custom header, custom footer, and an `ignore_files` glob.\n',
+  root_footer: '\n## Contributing\n\nSee the parent project for guidelines.\n',
+  // Hide the build-output directory without having to drop a `.gitignore`.
+  ignore_files: ['build/']
+};

--- a/examples/with-config/package.json
+++ b/examples/with-config/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "with-config",
+  "version": "0.1.0",
+  "description": "Example that overrides the auto-generated figlet, supplies custom headers/footers, and adds an ignore_files glob.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/example/with-config.git"
+  }
+}

--- a/examples/with-config/src/README.md
+++ b/examples/with-config/src/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / examples / with-config / src
 
 ```
 
@@ -17,21 +17,14 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [index.js](./index.js)
 This directory is part of the awesome-readme project.
 ## Directory Tree
-[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+[<- Previous](../README.md)
 ```
 src/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   └─── index.js
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/with-config/src/index.js
+++ b/examples/with-config/src/index.js
@@ -1,0 +1,4 @@
+// Source file for the with-config example. Lives under `src/` so the root
+// README's auto-generated file list keeps it, while `build/` (if present) is
+// stripped by the `ignore_files` glob in the config.
+module.exports = { greeting: 'hello from with-config' };

--- a/test/README.md
+++ b/test/README.md
@@ -1,3 +1,4 @@
+<!-- awesome-readme:start -->
 
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
@@ -16,7 +17,7 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [cli.test.js](./cli.test.js) - [filterFiles.test.js](./filterFiles.test.js) - [tree.test.js](./tree.test.js)
+ - [README.md](./README.md) - [cli.test.js](./cli.test.js) - [filterFiles.test.js](./filterFiles.test.js) - [preserveReadme.test.js](./preserveReadme.test.js) - [tree.test.js](./tree.test.js) - [walk.test.js](./walk.test.js)
 This directory is part of the awesome-readme project.
 ## Directory Tree
 [<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
@@ -25,6 +26,10 @@ test/
    ├─── README.md
    ├─── cli.test.js
    ├─── filterFiles.test.js
-   └─── tree.test.js
+   ├─── preserveReadme.test.js
+   ├─── tree.test.js
+   └─── walk.test.js
 ```
 ## Don't hesitate to contribute to this project.
+
+<!-- awesome-readme:end -->


### PR DESCRIPTION
Fixes #93.

Adds three small, self-contained example projects under `examples/` so users can see what the generator produces without running it first:

- **`minimal/`** — the zero-config path: one `package.json` and one source file. The figlet banner is auto-generated from `package.json` `name`.
- **`nested/`** — a monorepo-style layout with `src/lib/` two levels deep and a parallel `test/` directory. Exercises the recursive directory walk.
- **`with-config/`** — demonstrates overriding the figlet banner (`figlet_text` + `figlet_font`), customising `root_header` / `root_footer`, and using an `ignore_files` glob.

Each example ships with its own generated `README.md` so the tree is browsable on GitHub. The `examples/README.md` uses the preservation markers introduced by #86 to keep a hand-written introduction outside the regenerated region, mirroring the pattern the tool supports for user-maintained READMEs.

The `examples/` directory is not published to npm (`package.json` `files` is restricted to `dist/`, `LICENSE` and `README.md`).

## Acceptance criteria

- [x] At least one documented example exists (three, in fact)
- [x] Example output is checked in (each example ships with its generated `README.md`)
- [x] Documentation explains how to regenerate the examples

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run format:check` — pass
- `npm test` — 77/77 pass