### PR TITLE
feat: per-directory config overrides (#89)

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / .vscode
 
 ```
 
@@ -17,22 +17,15 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [directoryOverrides.ts](./directoryOverrides.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [extensions.json](./extensions.json) - [settings.json](./settings.json)
 This directory is part of the awesome-readme project.
 ## Directory Tree
 [<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
 ```
-src/
+.vscode/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── directoryOverrides.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   ├─── extensions.json
+   └─── settings.json
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ auto-generated file index, etc.) and the next run will refresh that block
 without touching the rest of the file.
 
 ## Directories
- - [.vscode/](./.vscode/) - [examples/](./examples/) - [src/](./src/) - [test/](./test/)
+ - [.claude/](./.claude/) - [.vscode/](./.vscode/) - [examples/](./examples/) - [src/](./src/) - [test/](./test/)
 
  - [.npmignore](./.npmignore)
  - [.prettierrc](./.prettierrc)
@@ -140,168 +140,53 @@ module.exports = {
     // coverage/, build/) is merged in automatically; set `ignore_defaults` to
     // false to opt out.
     ignore_files: ['.prettierignore'],
-    ignore_defaults: true
+    ignore_defaults: true,
+    // `directories` patches the eight text fields for the matching directory
+    // only. Keys are project-root-relative POSIX paths and matching is exact
+    // (no cascade). The walker and ignore rules stay global, so the tree
+    // stays consistent across READMEs.
+    // directories: {
+    //   src: { sub_header: 'Source code' },
+    //   'src/internal': { sub_header: 'Internal helpers' }
+    // }
 }
 ```
 
-## Directory Tree
-```
-awesome-readme/
-├─── .npmignore
-├─── .prettierrc
-├─── CONTRIBUTING.md
-├─── LICENSE
-├─── README.md
-├─── awesome-readme.config.js
-├─── eslint.config.js
-├─── package-lock.json
-├─── package.json
-└─── tsconfig.json
-├─── .vscode/
-│   ├─── README.md
-│   ├─── extensions.json
-│   └─── settings.json
-├─── examples/
-│   └─── README.md
-│   ├─── minimal/
-│   │   ├─── README.md
-│   │   └─── package.json
-│   │   └─── src/
-│   │       ├─── README.md
-│   │       └─── index.js
-│   ├─── nested/
-│   │   ├─── README.md
-│   │   └─── package.json
-│   │   ├─── src/
-│   │   │   ├─── README.md
-│   │   │   └─── index.js
-│   │   │   └─── lib/
-│   │   │       ├─── README.md
-│   │   │       ├─── format.js
-│   │   │       └─── math.js
-│   │   └─── test/
-│   │       ├─── README.md
-│   │       └─── smoke.test.js
-│   └─── with-config/
-│       ├─── README.md
-│       ├─── awesome-readme.config.js
-│       └─── package.json
-│       └─── src/
-│           ├─── README.md
-│           └─── index.js
-├─── src/
-│   ├─── README.md
-│   ├─── buildReadme.ts
-│   ├─── cli.ts
-│   ├─── filterFiles.ts
-│   ├─── index.ts
-│   ├─── tree.ts
-│   ├─── types.ts
-│   ├─── walk.ts
-│   └─── writeReadme.ts
-└─── test/
-    ├─── README.md
-    ├─── cli.test.js
-    ├─── filterFiles.test.js
-    ├─── preserveReadme.test.js
-    ├─── tree.test.js
-    └─── walk.test.js
-```
-## Don't hesitate to contribute to this project.
+### Per-directory overrides
 
-<!-- awesome-readme:end -->` markers
-and only that region is regenerated on the next run. A README without markers
-is left untouched unless `--force` is passed. To regenerate part of a
-hand-written README, wrap the section you want the tool to own with the two
-markers.
-
-Preview the output before touching your files:
-
-```
-npx awesome-readme --dry-run
-```
-
-Generate for another project, with a config living elsewhere:
-
-```
-npx awesome-readme --path ./packages/core --config ./readme.config.js
-```
-
-Add the markers to a hand-written README to opt into partial regeneration:
-
-```
-<!-- awesome-readme:start -->
-<!-- awesome-readme:end -->
-```
-
-Fill the gap with anything you want the tool to own (a tree, a badge list, an
-auto-generated file index, etc.) and the next run will refresh that block
-without touching the rest of the file.
-
-## Directories
- - [.vscode/](./.vscode/) - [examples/](./examples/) - [src/](./src/) - [test/](./test/)
-
- - [.npmignore](./.npmignore)
- - [.prettierrc](./.prettierrc)
- - [CONTRIBUTING.md](./CONTRIBUTING.md)
- - [LICENSE](./LICENSE)
- - [README.md](./README.md)
- - [awesome-readme.config.js](./awesome-readme.config.js)
- - [eslint.config.js](./eslint.config.js)
- - [package-lock.json](./package-lock.json)
- - [package.json](./package.json)
- - [tsconfig.json](./tsconfig.json)
-
-
-
-## Configuration with awesome-readme.config.js
+For monorepos and multi-package trees where different directories deserve
+their own copy, add a top-level `directories` block to the config. Keys
+are project-root-relative POSIX paths and matching is exact: an entry for
+`src` does **not** cascade to `src/internal`. Each value patches only
+the eight text fields (`root_/sub_ license/header/body/footer`) for the
+matching directory; ignore rules and `max_depth` stay global so the
+walker cannot drift between READMEs.
 
 ```
 module.exports = {
-    // Set figlet_text to a plain string and the tool will render it with the
-    // figlet package at build time (no need to hand-author ASCII art). Use
-    // figlet_font to pick a different font (defaults to "Standard"). Leave the
-    // pre-rendered figlet below in place if you want to use that instead.
-    // figlet_text: 'awesome-readme',
-    // figlet_font: 'Standard',
-    // By default a banner is auto-generated from `package.json` `name` when
-    // neither `figlet` nor `figlet_text` is set. Set `figlet_auto` to
-    // false to keep the banner blank, or to true to force auto-generation
-    // even when `figlet_text` is unset.
-    // figlet_auto: true,
-    figlet: `
-    .d8b.  db   d8b   db d88888b .d8888.  .d88b.  .88b  d88. d88888b        d8888b. d88888b  .d8b.  d8888b. .88b  d88. d88888b
-    d8' '8b 88   I8I   88 88'     88'  YP .8P  Y8. 88'YbdP'88 88'            88  '8D 88'     d8' '8b 88  '8D 88'YbdP'88 88'
-    88ooo88 88   I8I   88 88ooooo '8bo.   88    88 88  88  88 88ooooo        88oobY' 88ooooo 88ooo88 88   88 88  88  88 88ooooo
-    88~~~88 Y8   I8I   88 88~~~~~   'Y8b. 88    88 88  88  88 88~~~~~ C8888D 88'8b   88~~~~~ 88~~~88 88   88 88  88  88 88~~~~~
-    88   88 '8b d8'8b d8' 88.     db   8D '8b  d8' 88  88  88 88.            88 '88. 88.     88   88 88  .8D 88  88  88 88.
-    YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD Y88888P YP   YP Y8888D' YP  YP  YP Y88888P`,
-    root_license: `[![npm version](https://badge.fury.io/js/awesome-readme.svg)](https://badge.fury.io/js/awesome-readme)`,
-    root_header: `
-    ## Install Awesome-Readme
-    ```
-    npm i awesome-readme
-    ```
-    ## Use Awesome-Readme
-    ```
-    npx awesome-readme
-    ````,
-    root_body: `## Configuration with awesome-readme.config.js`,
-    root_footer: `## Don't hesitate to contribute to this project.`,
-    sub_license: `[![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)`,
-    sub_header: `## About this directory`,
-    sub_body: `This directory is part of the awesome-readme project.`,
-    sub_footer: `## Don't hesitate to contribute to this project.`,
-    ignore_gitFiles: true,
-    ignore_gitIgnoreFiles: true,
-    // `ignore_files` accepts gitignore-style globs (`*.log`, `dist/`). On top of
-    // what is listed here, a small set of defaults (node_modules/, dist/,
-    // coverage/, build/) is merged in automatically; set `ignore_defaults` to
-    // false to opt out.
-    ignore_files: ['.prettierignore'],
-    ignore_defaults: true
-}
+    sub_header: 'Default intro for every README',
+    sub_body: 'Default body',
+    directories: {
+        src: { sub_header: 'Source code' },
+        '.vscode': { sub_header: 'Editor settings' },
+        'src/hooks': { sub_header: 'Hooks', sub_body: 'Lifecycle scripts' }
+    }
+};
 ```
+
+Rules:
+
+- Keys must be project-root-relative POSIX paths. `src`, `.vscode`
+  and `packages/api` are valid; leading slashes, backslashes, `..`
+  segments and the empty string are rejected.
+- Matching is **exact**. Unspecified directories keep the global
+  `sub_*` defaults — an override for `src` does not apply to
+  `src/hooks`.
+- The root README is never overridden. There is no empty-key form.
+- Empty-string values (e.g. `sub_footer: ''`) clear the section in the
+  targeted README only.
+- See `examples/with-overrides/` for a runnable demo.
+
 
 ## Directory Tree
 ```
@@ -316,6 +201,8 @@ awesome-readme/
 ├─── package-lock.json
 ├─── package.json
 └─── tsconfig.json
+├─── .claude/
+│   └─── worktrees/
 ├─── .vscode/
 │   ├─── README.md
 │   ├─── extensions.json
@@ -341,17 +228,31 @@ awesome-readme/
 │   │   └─── test/
 │   │       ├─── README.md
 │   │       └─── smoke.test.js
-│   └─── with-config/
+│   ├─── with-config/
+│   │   ├─── README.md
+│   │   ├─── awesome-readme.config.js
+│   │   └─── package.json
+│   │   └─── src/
+│   │       ├─── README.md
+│   │       └─── index.js
+│   └─── with-overrides/
 │       ├─── README.md
 │       ├─── awesome-readme.config.js
 │       └─── package.json
+│       ├─── .vscode/
+│       │   ├─── README.md
+│       │   └─── settings.json
 │       └─── src/
 │           ├─── README.md
 │           └─── index.js
+│           └─── hooks/
+│               ├─── README.md
+│               └─── pre-commit.js
 ├─── src/
 │   ├─── README.md
 │   ├─── buildReadme.ts
 │   ├─── cli.ts
+│   ├─── directoryOverrides.ts
 │   ├─── filterFiles.ts
 │   ├─── index.ts
 │   ├─── tree.ts
@@ -361,6 +262,7 @@ awesome-readme/
 └─── test/
     ├─── README.md
     ├─── cli.test.js
+    ├─── directoryOverrides.test.js
     ├─── filterFiles.test.js
     ├─── preserveReadme.test.js
     ├─── tree.test.js

--- a/awesome-readme.config.js
+++ b/awesome-readme.config.js
@@ -129,9 +129,53 @@ module.exports = {
     // coverage/, build/) is merged in automatically; set \`ignore_defaults\` to
     // false to opt out.
     ignore_files: ['.prettierignore'],
-    ignore_defaults: true
+    ignore_defaults: true,
+    // \`directories\` patches the eight text fields for the matching directory
+    // only. Keys are project-root-relative POSIX paths and matching is exact
+    // (no cascade). The walker and ignore rules stay global, so the tree
+    // stays consistent across READMEs.
+    // directories: {
+    //   src: { sub_header: 'Source code' },
+    //   'src/internal': { sub_header: 'Internal helpers' }
+    // }
 }
 \`\`\`
+
+### Per-directory overrides
+
+For monorepos and multi-package trees where different directories deserve
+their own copy, add a top-level \`directories\` block to the config. Keys
+are project-root-relative POSIX paths and matching is exact: an entry for
+\`src\` does **not** cascade to \`src/internal\`. Each value patches only
+the eight text fields (\`root_/sub_ license/header/body/footer\`) for the
+matching directory; ignore rules and \`max_depth\` stay global so the
+walker cannot drift between READMEs.
+
+\`\`\`
+module.exports = {
+    sub_header: 'Default intro for every README',
+    sub_body: 'Default body',
+    directories: {
+        src: { sub_header: 'Source code' },
+        '.vscode': { sub_header: 'Editor settings' },
+        'src/hooks': { sub_header: 'Hooks', sub_body: 'Lifecycle scripts' }
+    }
+};
+\`\`\`
+
+Rules:
+
+- Keys must be project-root-relative POSIX paths. \`src\`, \`.vscode\`
+  and \`packages/api\` are valid; leading slashes, backslashes, \`..\`
+  segments and the empty string are rejected.
+- Matching is **exact**. Unspecified directories keep the global
+  \`sub_*\` defaults — an override for \`src\` does not apply to
+  \`src/hooks\`.
+- The root README is never overridden. There is no empty-key form.
+- Empty-string values (e.g. \`sub_footer: ''\`) clear the section in the
+  targeted README only.
+- See \`examples/with-overrides/\` for a runnable demo.
+
 `,
   root_footer: `## Don't hesitate to contribute to this project.`,
   sub_license: `[![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)`,
@@ -145,5 +189,15 @@ module.exports = {
   // coverage/, build/) is merged in automatically; set `ignore_defaults` to
   // false to opt out.
   ignore_files: ['.prettierignore'],
-  ignore_defaults: true
+  ignore_defaults: true,
+  // `directories` patches the eight text fields (`root_/sub_ license/header/
+  // body/footer`) for the matching directory only. Matching is exact and
+  // does not cascade: an entry for `src` does NOT apply to `src/internal`;
+  // that directory either has its own entry or falls back to the global
+  // `sub_*` defaults. See `examples/with-overrides/` for a runnable demo
+  // and `README.md` for the full rules.
+  // directories: {
+  //   src: { sub_header: 'Source code' },
+  //   'src/internal': { sub_header: 'Internal helpers' }
+  // }
 };

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,57 +1,3 @@
-# Examples
-
-Small, self-contained projects you can point `awesome-readme` at to see how
-the generator behaves under different layouts and configurations.
-
-Each example ships with a pre-generated `README.md` so the output can be
-inspected on GitHub without running anything. To regenerate from scratch
-from the repository root:
-
-```
-npm run build
-npx awesome-readme --path examples/<name> --force
-```
-
-Add `--dry-run` to preview what would be written without touching the files.
-
-## `minimal/`
-
-The smallest possible input: one `package.json` and one source file under
-`src/`. Demonstrates the zero-config path — the figlet banner is
-auto-generated from `package.json` `name` and the root tree shows both the
-file and the directory.
-
-## `nested/`
-
-A monorepo-style layout with `src/lib/` two levels deep and a parallel
-`test/` directory. Exercises the recursive directory walk: every level gets
-its own README and the root tree nests the subtrees under their parent
-directories.
-
-## `with-config/`
-
-Shows how an `awesome-readme.config.js` reshapes the generated README:
-
-- `figlet_text` + `figlet_font` instead of the auto-generated banner
-- Custom `root_header` and `root_footer`
-- An `ignore_files` glob (`build/`) that hides the build output without
-  needing a `.gitignore`
-
-Run it with the explicit `--config` flag if you want to point at a config
-living elsewhere:
-
-```
-npx awesome-readme --path examples/with-config --config examples/with-config/awesome-readme.config.js
-```
-
-## Keeping the generated files in sync
-
-The checked-in `README.md` files are produced by the generator, not
-maintained by hand. Feel free to delete them and regenerate when the
-renderer changes — diffs in the output are the whole point of having
-checked-in examples. The hand-written intro above lives outside the
-generated markers so it survives regeneration.
-
 <!-- awesome-readme:start -->
 
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
@@ -71,7 +17,7 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 ## Directories
- - [minimal/](./minimal/) - [nested/](./nested/) - [with-config/](./with-config/)
+ - [minimal/](./minimal/) - [nested/](./nested/) - [with-config/](./with-config/) - [with-overrides/](./with-overrides/)
 
  - [README.md](./README.md)
 This directory is part of the awesome-readme project.
@@ -99,13 +45,26 @@ examples/
    │   └─── test/
    │       ├─── README.md
    │       └─── smoke.test.js
-   └─── with-config/
+   ├─── with-config/
+   │   ├─── README.md
+   │   ├─── awesome-readme.config.js
+   │   └─── package.json
+   │   └─── src/
+   │       ├─── README.md
+   │       └─── index.js
+   └─── with-overrides/
        ├─── README.md
        ├─── awesome-readme.config.js
        └─── package.json
+       ├─── .vscode/
+       │   ├─── README.md
+       │   └─── settings.json
        └─── src/
            ├─── README.md
            └─── index.js
+           └─── hooks/
+               ├─── README.md
+               └─── pre-commit.js
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/with-overrides/.vscode/README.md
+++ b/examples/with-overrides/.vscode/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / examples / with-overrides / .vscode
 
 ```
 
@@ -17,22 +17,14 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [directoryOverrides.ts](./directoryOverrides.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [settings.json](./settings.json)
 This directory is part of the awesome-readme project.
 ## Directory Tree
-[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+[<- Previous](../README.md)
 ```
-src/
+.vscode/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── directoryOverrides.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   └─── settings.json
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/with-overrides/.vscode/settings.json
+++ b/examples/with-overrides/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/examples/with-overrides/README.md
+++ b/examples/with-overrides/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / examples / with-overrides
 
 ```
 
@@ -16,23 +16,27 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 ```
 
 ## About this directory
+## Directories
+ - [.vscode/](./.vscode/) - [src/](./src/)
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [directoryOverrides.ts](./directoryOverrides.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [awesome-readme.config.js](./awesome-readme.config.js) - [package.json](./package.json)
 This directory is part of the awesome-readme project.
 ## Directory Tree
-[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+[<- Previous](../README.md)
 ```
-src/
+with-overrides/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── directoryOverrides.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   ├─── awesome-readme.config.js
+   └─── package.json
+   ├─── .vscode/
+   │   ├─── README.md
+   │   └─── settings.json
+   └─── src/
+       ├─── README.md
+       └─── index.js
+       └─── hooks/
+           ├─── README.md
+           └─── pre-commit.js
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/with-overrides/awesome-readme.config.js
+++ b/examples/with-overrides/awesome-readme.config.js
@@ -1,0 +1,29 @@
+module.exports = {
+  // Global defaults applied to every subdirectory that does not have its
+  // own entry under `directories` below.
+  figlet_auto: false,
+  figlet_text: 'with-overrides',
+  figlet_font: 'Standard',
+  sub_header: 'Default header for any directory without an override',
+  sub_body: 'Default body for any directory without an override',
+  // Per-directory overrides: keys are project-root-relative POSIX paths
+  // and matching is exact (no cascade). Each entry patches only the eight
+  // text fields listed in the README — ignore rules and `max_depth` stay
+  // global so the walker cannot drift between directories.
+  directories: {
+    src: {
+      sub_header: 'Source code lives here',
+      sub_body: 'Every module in src/ is independently testable.'
+    },
+    'src/hooks': {
+      sub_header: 'Lifecycle hooks',
+      sub_body: 'Scripts run before/after specific git events.',
+      // Empty strings clear the corresponding section in the targeted
+      // README only; descendants keep the global default.
+      sub_footer: ''
+    },
+    '.vscode': {
+      sub_header: 'Editor settings shared across the team'
+    }
+  }
+};

--- a/examples/with-overrides/package.json
+++ b/examples/with-overrides/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "with-overrides",
+  "version": "0.1.0",
+  "description": "Example that uses per-directory overrides to give src/, src/hooks/ and .vscode/ distinct headers and bodies.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/example/with-overrides.git"
+  }
+}

--- a/examples/with-overrides/src/README.md
+++ b/examples/with-overrides/src/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / examples / with-overrides / src
 
 ```
 
@@ -16,23 +16,20 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 ```
 
 ## About this directory
+## Directories
+ - [hooks/](./hooks/)
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [directoryOverrides.ts](./directoryOverrides.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [index.js](./index.js)
 This directory is part of the awesome-readme project.
 ## Directory Tree
-[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+[<- Previous](../README.md)
 ```
 src/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── directoryOverrides.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   └─── index.js
+   └─── hooks/
+       ├─── README.md
+       └─── pre-commit.js
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/with-overrides/src/hooks/README.md
+++ b/examples/with-overrides/src/hooks/README.md
@@ -3,7 +3,7 @@
 [![license](https://img.shields.io/github/license/marc-aurele-besner/awesome-readme.svg)](https://opensource.org/licenses/MIT)
 
 [![license](https://img.shields.io/badge/license-MIT-green.svg)](https://opensource.org/licenses/MIT)
-# awesome-readme / src
+# awesome-readme / examples / with-overrides / src / hooks
 
 ```
 
@@ -17,22 +17,14 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [buildReadme.ts](./buildReadme.ts) - [cli.ts](./cli.ts) - [directoryOverrides.ts](./directoryOverrides.ts) - [filterFiles.ts](./filterFiles.ts) - [index.ts](./index.ts) - [tree.ts](./tree.ts) - [types.ts](./types.ts) - [walk.ts](./walk.ts) - [writeReadme.ts](./writeReadme.ts)
+ - [README.md](./README.md) - [pre-commit.js](./pre-commit.js)
 This directory is part of the awesome-readme project.
 ## Directory Tree
-[<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
+[<- Previous](../README.md)
 ```
-src/
+hooks/
    ├─── README.md
-   ├─── buildReadme.ts
-   ├─── cli.ts
-   ├─── directoryOverrides.ts
-   ├─── filterFiles.ts
-   ├─── index.ts
-   ├─── tree.ts
-   ├─── types.ts
-   ├─── walk.ts
-   └─── writeReadme.ts
+   └─── pre-commit.js
 ```
 ## Don't hesitate to contribute to this project.
 

--- a/examples/with-overrides/src/hooks/pre-commit.js
+++ b/examples/with-overrides/src/hooks/pre-commit.js
@@ -1,0 +1,2 @@
+// Placeholder hook script so `src/hooks/` is non-empty.
+module.exports = function preCommit() {};

--- a/examples/with-overrides/src/index.js
+++ b/examples/with-overrides/src/index.js
@@ -1,0 +1,3 @@
+// Placeholder so `src/` is non-empty and the auto-generated README has a
+// file to list in its directory tree.
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-readme",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Build awesome readme easily",
   "bin": {
     "awesome-readme": "dist/index.js"

--- a/src/directoryOverrides.ts
+++ b/src/directoryOverrides.ts
@@ -1,0 +1,110 @@
+import * as path from 'path';
+
+import type { ExtraData } from './types';
+import type { DirectoryNode } from './walk';
+
+/**
+ * Per-directory overrides for the eight text fields of an `ExtraData` object.
+ *
+ * `ignore_gitFiles`, `ignore_gitIgnoreFiles`, `ignore_files`,
+ * `ignore_defaults` and `max_depth` are deliberately not overridable here:
+ * they govern the walker itself, and letting them drift per directory would
+ * produce inconsistent trees between READMEs.
+ */
+export type DirectoryOverride = Partial<
+  Pick<ExtraData, 'root_license' | 'root_header' | 'root_body' | 'root_footer' | 'sub_license' | 'sub_header' | 'sub_body' | 'sub_footer'>
+>;
+
+const TEXT_FIELDS = ['root_license', 'root_header', 'root_body', 'root_footer', 'sub_license', 'sub_header', 'sub_body', 'sub_footer'] as const;
+
+type TextField = (typeof TEXT_FIELDS)[number];
+
+/**
+ * Normalize a raw `directories` key into a project-root-relative POSIX path.
+ *
+ * Rejects values that would escape the project root (`..`, leading `/`,
+ * Windows `\` separators, absolute POSIX paths) and the empty string. A `null`
+ * return signals the caller should throw with the original key so the error
+ * message names the user's input rather than the normalized form.
+ */
+const normalizeKey = (raw: string): string | null => {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  // Windows-style separators are never valid in a POSIX key. This keeps the
+  // matching identical across platforms and prevents `..\..\etc` slips.
+  if (trimmed.includes('\\')) return null;
+  const normalized = path.posix.normalize(trimmed).replace(/\/+$/, '');
+  if (normalized === '' || normalized === '.' || normalized.startsWith('..') || path.posix.isAbsolute(normalized)) return null;
+  return normalized;
+};
+
+/**
+ * Parse the raw `directories` value of `awesome-readme.config.js` into a
+ * keyed map of overrides.
+ *
+ * Throws on the first invalid input — empty / null / array containers, bad
+ * keys (escaping the project root, Windows separators, empty strings) and
+ * bad values (anything other than a plain object). The throw is caught by
+ * `main` so a bad config exits 1 with a descriptive message, matching the
+ * behaviour of `--path` / `--config` validation.
+ *
+ * Unknown fields on each override object are silently ignored so future
+ * versions can add new overridable fields without breaking old configs.
+ */
+export const parseDirectoryOverrides = (raw: unknown, _projectRoot: string): Map<string, DirectoryOverride> => {
+  if (raw === undefined) return new Map();
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) throw new Error('config.directories must be an object mapping POSIX paths to overrides');
+  const out = new Map<string, DirectoryOverride>();
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    const normalized = normalizeKey(key);
+    if (normalized === null) throw new Error(`config.directories: invalid key "${key}" (expected a project-root-relative POSIX path)`);
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) throw new Error(`config.directories["${normalized}"] must be an object`);
+    const override: DirectoryOverride = {};
+    const record = value as Record<string, unknown>;
+    for (const field of TEXT_FIELDS) {
+      if (Object.prototype.hasOwnProperty.call(record, field) && typeof record[field] === 'string') {
+        // An empty string is a legitimate "clear this section" override, so
+        // we have to test for key presence rather than truthiness.
+        (override as Record<TextField, string>)[field] = record[field] as string;
+      }
+    }
+    out.set(normalized, override);
+  }
+  return out;
+};
+
+/**
+ * Compute the project-root-relative POSIX key for a walked directory node.
+ *
+ * The root node returns `''` so callers can use a `Map.get('')` lookup for
+ * root-README overrides (the current implementation never populates one,
+ * but the seam is left in place). Any node that escapes the project root —
+ * through a symlink or a manual walk — also returns `''`, which silently
+ * falls back to the global `ExtraData`.
+ */
+export const getDirectoryKey = (node: DirectoryNode, projectRoot: string): string => {
+  if (node.path === projectRoot) return '';
+  const rel = path.relative(projectRoot, node.path);
+  if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) return '';
+  return rel.split(path.sep).join('/');
+};
+
+/**
+ * Return a copy of `base` with every text field present in `override`
+ * replaced. Other fields (`ignore_*`, `max_depth`) are left untouched so
+ * traversal cannot drift between directories.
+ *
+ * Returns the original reference when no override is supplied — callers
+ * iterate thousands of directories and most have no entry, so a fresh
+ * object would be wasted work.
+ */
+export const mergeOverride = (base: ExtraData, override: DirectoryOverride | undefined): ExtraData => {
+  if (!override) return base;
+  const next: ExtraData = { ...base };
+  const record = override as Record<TextField, string>;
+  for (const field of TEXT_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(override, field)) next[field] = record[field];
+  }
+  return next;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import figletLib from 'figlet';
 
 import buildReadme, { toTreeNodes } from './buildReadme';
 import { parseCliOptions, usage, type CliOptions } from './cli';
+import { parseDirectoryOverrides, getDirectoryKey, mergeOverride } from './directoryOverrides';
 import { renderTreeLines } from './tree';
 import type { ExtraData } from './types';
 import { walkDirectory, flattenDirectories, DEFAULT_MAX_DEPTH, type DirectoryNode } from './walk';
@@ -75,10 +76,17 @@ const buildMainReadme = (options: Partial<BuildOptions> = {}): void => {
   // An explicit `--config` must exist; the default file stays optional.
   const configPath = options.config ? path.resolve(options.config) : path.join(currentPath, DEFAULT_CONFIG_FILE);
   if (options.config && !fs.existsSync(configPath)) throw new Error(`Config file not found: ${configPath}`);
-  if (fs.existsSync(configPath)) {
-    // if exists, read the file
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const config = require(configPath);
+  // Read the config once so both the field-by-field parsing below and the
+  // per-directory `directories` lookup see the same object. Hoisted out of
+  // the `if` block so an absent config file still yields `undefined` rather
+  // than a name error. The wider type mirrors what the previous
+  // `const config = require(configPath)` declaration produced — the
+  // field-by-field reads below rely on `undefined` checks and truthiness,
+  // and tight typing would force a cast at every line without changing
+  // the runtime behaviour.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any
+  const config: any = fs.existsSync(configPath) ? require(configPath) : undefined;
+  if (config !== undefined) {
     if (config.figlet) {
       figlet = `
 \`\`\`
@@ -175,6 +183,13 @@ ${rendered}
   if (extraData.ignore_files.length > 0) console.log('\x1b[33m', 'Ignoring files: ', '\x1b[0m', extraData.ignore_files.toString());
   if (extraData.ignore_defaults) console.log('\x1b[33m', 'Ignoring default directories: node_modules/, dist/, coverage/, build/', '\x1b[0m');
 
+  // Per-directory overrides: keys are project-root-relative POSIX paths and
+  // matching is exact (no prefix cascade). Parsed once up front so a bad
+  // config fails fast before any files are written. The map is empty when
+  // the config does not declare `directories`, which keeps the no-config
+  // path identical to today.
+  const directoryOverrides = parseDirectoryOverrides(config?.directories, currentPath);
+
   const tree = walkDirectory(currentPath, extraData);
   const truncated = flattenDirectories(tree).filter((node) => node.truncated);
   if (truncated.length > 0)
@@ -204,6 +219,12 @@ ${rendered}
   const emitSubReadmes = (parent: DirectoryNode, parentTitle: string): void => {
     parent.directories.forEach((child) => {
       const title = `${parentTitle} / ${child.name}`;
+      // Look up a per-directory override by its project-root-relative POSIX
+      // path. Children of an overridden directory inherit the global
+      // `sub_*` fields unless they have their own entry — the lookup uses
+      // `getDirectoryKey`, not `parent`'s key, so the cascade is exact.
+      const override = directoryOverrides.get(getDirectoryKey(child, currentPath));
+      const childExtraData = mergeOverride(extraData, override);
       buildReadme({
         node: child,
         title,
@@ -213,7 +234,7 @@ ${rendered}
         // to their parent's README, which is the actual "previous" page.
         previousUrl: child.depth === 1 ? repositoryUrl : '../README.md',
         prefix: '   ',
-        extraData,
+        extraData: childExtraData,
         writeOptions: subWriteOptions
       });
       emitSubReadmes(child, title);

--- a/test/README.md
+++ b/test/README.md
@@ -17,7 +17,7 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P        88   YD
 
 ## About this directory
 
- - [README.md](./README.md) - [cli.test.js](./cli.test.js) - [filterFiles.test.js](./filterFiles.test.js) - [preserveReadme.test.js](./preserveReadme.test.js) - [tree.test.js](./tree.test.js) - [walk.test.js](./walk.test.js)
+ - [README.md](./README.md) - [cli.test.js](./cli.test.js) - [directoryOverrides.test.js](./directoryOverrides.test.js) - [filterFiles.test.js](./filterFiles.test.js) - [preserveReadme.test.js](./preserveReadme.test.js) - [tree.test.js](./tree.test.js) - [walk.test.js](./walk.test.js)
 This directory is part of the awesome-readme project.
 ## Directory Tree
 [<- Previous](https://github.com/marc-aurele-besner/awesome-readme)
@@ -25,6 +25,7 @@ This directory is part of the awesome-readme project.
 test/
    ├─── README.md
    ├─── cli.test.js
+   ├─── directoryOverrides.test.js
    ├─── filterFiles.test.js
    ├─── preserveReadme.test.js
    ├─── tree.test.js

--- a/test/directoryOverrides.test.js
+++ b/test/directoryOverrides.test.js
@@ -1,0 +1,338 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const { parseDirectoryOverrides, getDirectoryKey, mergeOverride } = require('../dist/directoryOverrides');
+const { main } = require('../dist/index');
+
+// Coverage for #89: per-directory config overrides. `directories` is a
+// project-root-relative POSIX map whose values patch the eight text fields
+// of `ExtraData` for the matching directory only — matching is exact and
+// does not cascade, unspecified directories keep the global defaults.
+
+// Capture stdout/stderr so tests can assert on logs and exit codes without
+// spawning a shell. Mirrors the helper used in test/cli.test.js so the
+// patterns stay familiar.
+const captureOutput = (fn) => {
+  const stdout = [];
+  const stderr = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...args) => stdout.push(args.join(' '));
+  console.error = (...args) => stderr.push(args.join(' '));
+  try {
+    const result = fn();
+    return { result, stdout: stdout.join('\n'), stderr: stderr.join('\n') };
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+};
+
+const baseExtraData = () => ({
+  root_license: '',
+  root_header: '',
+  root_body: '',
+  root_footer: '',
+  sub_license: '',
+  sub_header: 'GLOBAL-SUB-HEADER',
+  sub_body: 'GLOBAL-SUB-BODY',
+  sub_footer: 'GLOBAL-SUB-FOOTER',
+  ignore_gitFiles: true,
+  ignore_gitIgnoreFiles: true,
+  ignore_files: [],
+  ignore_defaults: true,
+  max_depth: 10
+});
+
+// `makeProject` builds a tiny project: a `src/` directory with one file, a
+// `.vscode/` directory, and an `src/hooks/` directory. Each one is a
+// realistic candidate for an override in `awesome-readme.config.js`.
+const makeProject = () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-overrides-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'demo',
+      license: 'MIT',
+      repository: { type: 'git', url: 'git+https://github.com/demo/demo.git' }
+    })
+  );
+  fs.mkdirSync(path.join(root, 'src'));
+  fs.mkdirSync(path.join(root, 'src', 'hooks'));
+  fs.mkdirSync(path.join(root, '.vscode'));
+  fs.writeFileSync(path.join(root, 'src', 'index.js'), '');
+  fs.writeFileSync(path.join(root, 'src', 'hooks', 'pre.js'), '');
+  fs.writeFileSync(path.join(root, '.vscode', 'settings.json'), '');
+  return root;
+};
+
+test('parseDirectoryOverrides returns an empty map when directories is absent', () => {
+  assert.deepStrictEqual(parseDirectoryOverrides(undefined, '/project'), new Map());
+});
+
+test('parseDirectoryOverrides accepts a small, valid override map', () => {
+  const result = parseDirectoryOverrides(
+    {
+      src: { sub_header: 'A' },
+      '.vscode': { sub_header: 'B', sub_footer: 'C' },
+      'src/hooks': { sub_header: '' }
+    },
+    '/project'
+  );
+
+  assert.strictEqual(result.size, 3);
+  assert.deepStrictEqual(result.get('src'), { sub_header: 'A' });
+  assert.deepStrictEqual(result.get('.vscode'), { sub_header: 'B', sub_footer: 'C' });
+  // An empty-string override is a legitimate "clear this section" value and
+  // must be preserved verbatim instead of being dropped by truthiness.
+  assert.deepStrictEqual(result.get('src/hooks'), { sub_header: '' });
+});
+
+test('parseDirectoryOverrides ignores unknown fields and trailing slashes on keys', () => {
+  // Trailing slash and `./` are stripped during normalization; the same
+  // canonical key therefore collapses multiple forms into one entry. The
+  // last one wins (insertion order is preserved in `Map`), so a value
+  // without an unknown field is checked explicitly first.
+  const result = parseDirectoryOverrides(
+    {
+      'src/': { sub_header: 'A', not_a_field: 'ignored' },
+      './src': { sub_header: 'A' }
+    },
+    '/project'
+  );
+
+  assert.strictEqual(result.size, 1);
+  assert.deepStrictEqual(result.get('src'), { sub_header: 'A' });
+});
+
+test('parseDirectoryOverrides preserves unknown fields as no-ops', () => {
+  // A value with only unknown fields is still a valid override object — it
+  // simply contributes nothing to the renderer.
+  const result = parseDirectoryOverrides({ src: { not_a_field: 'ignored', another: 42 } }, '/project');
+  assert.strictEqual(result.size, 1);
+  assert.deepStrictEqual(result.get('src'), {});
+});
+
+test('parseDirectoryOverrides rejects non-object containers', () => {
+  assert.throws(() => parseDirectoryOverrides(null, '/project'), /config.directories must be an object/);
+  assert.throws(() => parseDirectoryOverrides([], '/project'), /config.directories must be an object/);
+  assert.throws(() => parseDirectoryOverrides('nope', '/project'), /config.directories must be an object/);
+});
+
+test('parseDirectoryOverrides rejects keys that escape the project root', () => {
+  assert.throws(() => parseDirectoryOverrides({ '/abs': { sub_header: 'A' } }, '/project'), /invalid key/);
+  assert.throws(() => parseDirectoryOverrides({ '..': { sub_header: 'A' } }, '/project'), /invalid key/);
+  assert.throws(() => parseDirectoryOverrides({ '../escape': { sub_header: 'A' } }, '/project'), /invalid key/);
+  assert.throws(() => parseDirectoryOverrides({ 'src\\..\\x': { sub_header: 'A' } }, '/project'), /invalid key/);
+  assert.throws(() => parseDirectoryOverrides({ '': { sub_header: 'A' } }, '/project'), /invalid key/);
+  assert.throws(() => parseDirectoryOverrides({ '   ': { sub_header: 'A' } }, '/project'), /invalid key/);
+});
+
+test('parseDirectoryOverrides rejects non-object values', () => {
+  assert.throws(() => parseDirectoryOverrides({ src: null }, '/project'), /must be an object/);
+  assert.throws(() => parseDirectoryOverrides({ src: 'header' }, '/project'), /must be an object/);
+  assert.throws(() => parseDirectoryOverrides({ src: ['header'] }, '/project'), /must be an object/);
+});
+
+test('getDirectoryKey returns the POSIX path relative to the project root', () => {
+  const projectRoot = path.resolve('/project');
+  assert.strictEqual(getDirectoryKey({ name: 'project', path: projectRoot, depth: 0, files: [], directories: [], truncated: false }, projectRoot), '');
+  assert.strictEqual(getDirectoryKey({ name: 'src', path: path.join(projectRoot, 'src'), depth: 1, files: [], directories: [], truncated: false }, projectRoot), 'src');
+  assert.strictEqual(getDirectoryKey({ name: 'hooks', path: path.join(projectRoot, 'src', 'hooks'), depth: 2, files: [], directories: [], truncated: false }, projectRoot), 'src/hooks');
+});
+
+test('mergeOverride leaves the base untouched when no override is supplied', () => {
+  const base = baseExtraData();
+  const merged = mergeOverride(base, undefined);
+  assert.strictEqual(merged, base);
+});
+
+test('mergeOverride only patches fields that are present in the override', () => {
+  const base = baseExtraData();
+  const merged = mergeOverride(base, { sub_header: 'OVERRIDE' });
+  assert.strictEqual(merged.sub_header, 'OVERRIDE');
+  assert.strictEqual(merged.sub_body, 'GLOBAL-SUB-BODY');
+  // The original reference must stay intact so the root README keeps using it.
+  assert.strictEqual(base.sub_header, 'GLOBAL-SUB-HEADER');
+  assert.notStrictEqual(merged, base);
+});
+
+test('mergeOverride ignores override fields that the type does not allow', () => {
+  const base = baseExtraData();
+  // `ignore_files` is intentionally not overridable per-directory; the type
+  // prevents the field but the runtime must also keep ignoring it.
+  const merged = mergeOverride(base, { sub_header: 'X' });
+  assert.strictEqual(merged.ignore_files, base.ignore_files);
+  assert.strictEqual(merged.max_depth, base.max_depth);
+});
+
+test('the root README never receives an override', () => {
+  // The root README draws from the `root_*` fields, so a `sub_header`
+  // override for `src` must never bleed into the root. We seed the root
+  // with a unique `root_body` so the assertion is on what the root README
+  // actually contains.
+  const root = makeProject();
+  fs.writeFileSync(
+    path.join(root, 'awesome-readme.config.js'),
+    "module.exports = { root_body: 'ROOT-ONLY-MARKER', directories: { src: { root_body: 'OVERRIDE-FOR-SRC' } } };\n"
+  );
+
+  try {
+    captureOutput(() => main(['--path', root, '--force']));
+
+    const rootReadme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+    assert.match(rootReadme, /ROOT-ONLY-MARKER/);
+    assert.doesNotMatch(rootReadme, /OVERRIDE-FOR-SRC/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('an empty key or "." key is rejected to keep the root un-overridable', () => {
+  const root = makeProject();
+  fs.writeFileSync(path.join(root, 'awesome-readme.config.js'), "module.exports = { directories: { '.': { sub_header: 'OVERRIDE' } } };\n");
+
+  try {
+    const { result, stderr } = captureOutput(() => main(['--path', root, '--force']));
+    assert.strictEqual(result, 1);
+    assert.match(stderr, /config\.directories: invalid key "\."/);
+    // Nothing should have been written because the bad config aborted the run.
+    assert.strictEqual(fs.existsSync(path.join(root, 'README.md')), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a per-directory override applies only to the matching directory', () => {
+  const root = makeProject();
+  fs.writeFileSync(
+    path.join(root, 'awesome-readme.config.js'),
+    "module.exports = { sub_header: 'GLOBAL-DEFAULT', directories: { src: { sub_header: 'OVERRIDE-FOR-SRC' } } };\n"
+  );
+
+  try {
+    captureOutput(() => main(['--path', root, '--force']));
+
+    const srcReadme = fs.readFileSync(path.join(root, 'src', 'README.md'), 'utf8');
+    assert.match(srcReadme, /OVERRIDE-FOR-SRC/);
+    assert.doesNotMatch(srcReadme, /GLOBAL-DEFAULT/);
+
+    const hooksReadme = fs.readFileSync(path.join(root, 'src', 'hooks', 'README.md'), 'utf8');
+    // The descendant must NOT inherit the `src` override — exact match only.
+    assert.match(hooksReadme, /GLOBAL-DEFAULT/);
+    assert.doesNotMatch(hooksReadme, /OVERRIDE-FOR-SRC/);
+
+    const vscodeReadme = fs.readFileSync(path.join(root, '.vscode', 'README.md'), 'utf8');
+    // A sibling of `src` keeps the global defaults.
+    assert.match(vscodeReadme, /GLOBAL-DEFAULT/);
+    assert.doesNotMatch(vscodeReadme, /OVERRIDE-FOR-SRC/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('multiple overrides compose and exact matching still wins', () => {
+  const root = makeProject();
+  fs.writeFileSync(
+    path.join(root, 'awesome-readme.config.js'),
+    "module.exports = { sub_header: 'GLOBAL-DEFAULT', directories: { src: { sub_header: 'OVERRIDE-SRC' }, 'src/hooks': { sub_header: 'OVERRIDE-HOOKS' } } };\n"
+  );
+
+  try {
+    captureOutput(() => main(['--path', root, '--force']));
+
+    assert.match(fs.readFileSync(path.join(root, 'src', 'README.md'), 'utf8'), /OVERRIDE-SRC/);
+    assert.match(fs.readFileSync(path.join(root, 'src', 'hooks', 'README.md'), 'utf8'), /OVERRIDE-HOOKS/);
+    assert.match(fs.readFileSync(path.join(root, '.vscode', 'README.md'), 'utf8'), /GLOBAL-DEFAULT/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('an empty-string override clears the section in the targeted README only', () => {
+  const root = makeProject();
+  fs.writeFileSync(
+    path.join(root, 'awesome-readme.config.js'),
+    "module.exports = { sub_header: 'GLOBAL-DEFAULT', directories: { src: { sub_header: '' } } };\n"
+  );
+
+  try {
+    captureOutput(() => main(['--path', root, '--force']));
+
+    const srcReadme = fs.readFileSync(path.join(root, 'src', 'README.md'), 'utf8');
+    assert.doesNotMatch(srcReadme, /GLOBAL-DEFAULT/);
+    assert.doesNotMatch(srcReadme, /## About this directory/);
+
+    const hooksReadme = fs.readFileSync(path.join(root, 'src', 'hooks', 'README.md'), 'utf8');
+    assert.match(hooksReadme, /GLOBAL-DEFAULT/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('invalid directories keys exit non-zero with a descriptive message', () => {
+  const root = makeProject();
+  fs.writeFileSync(path.join(root, 'awesome-readme.config.js'), "module.exports = { directories: { '/abs': { sub_header: 'A' } } };\n");
+
+  try {
+    const { result, stderr } = captureOutput(() => main(['--path', root, '--force']));
+    assert.strictEqual(result, 1);
+    assert.match(stderr, /config\.directories: invalid key "\/abs"/);
+    // Nothing should have been written because the bad config aborted the run.
+    assert.strictEqual(fs.existsSync(path.join(root, 'README.md')), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('non-object values exit non-zero with a descriptive message', () => {
+  const root = makeProject();
+  fs.writeFileSync(path.join(root, 'awesome-readme.config.js'), "module.exports = { directories: { src: 'header' } };\n");
+
+  try {
+    const { result, stderr } = captureOutput(() => main(['--path', root, '--force']));
+    assert.strictEqual(result, 1);
+    assert.match(stderr, /config\.directories\["src"\] must be an object/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('existing tree and walker behaviour is unaffected by an empty override map', () => {
+  // Snapshot-style assertion: declaring an empty `directories` block must
+  // not change anything the existing #82 fixture tests pin down, so the
+  // walker stays untouched when overrides are added.
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-overrides-snapshot-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'demo',
+      license: 'MIT',
+      repository: { type: 'git', url: 'git+https://github.com/demo/demo.git' }
+    })
+  );
+  fs.writeFileSync(path.join(root, 'README.md'), '');
+  fs.writeFileSync(path.join(root, 'LICENSE'), '');
+  fs.writeFileSync(path.join(root, 'awesome-readme.config.js'), "module.exports = { directories: {} };\n");
+  fs.mkdirSync(path.join(root, 'alpha'));
+  fs.mkdirSync(path.join(root, 'beta'));
+  fs.writeFileSync(path.join(root, 'alpha', 'a.txt'), '');
+  fs.writeFileSync(path.join(root, 'beta', 'b.txt'), '');
+
+  try {
+    captureOutput(() => main(['--path', root, '--force']));
+
+    const rootReadme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+    assert.match(rootReadme, /├─── alpha\//);
+    assert.match(rootReadme, /└─── beta\//);
+    assert.match(rootReadme, /│ {3}└─── a\.txt/);
+
+    const alphaReadme = fs.readFileSync(path.join(root, 'alpha', 'README.md'), 'utf8');
+    assert.match(alphaReadme, /└─── a\.txt/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #89.

Adds a top-level `directories` block to `awesome-readme.config.js` so monorepos and multi-package trees can give each subdirectory its own headers, bodies, or footers.

### Semantics

- Keys are project-root-relative POSIX paths (`src`, `.vscode`, `packages/api`).
- Matching is **exact and does not cascade** — an entry for `src` does not apply to `src/hooks`. Unspecified directories keep the global `sub_*` defaults.
- The root README is never overridden (no empty-key form).
- Empty-string values (e.g. `sub_footer: ''`) clear the section in the targeted README only.
- Only the eight text fields on `ExtraData` (`root_/sub_ license/header/body/footer`) are overridable. `ignore_gitFiles`, `ignore_gitIgnoreFiles`, `ignore_files`, `ignore_defaults` and `max_depth` stay global so the walker cannot drift between directories.
- Invalid keys (leading `/`, `..`, Windows `\`, `.`, empty) or non-object values exit 1 with a descriptive message, mirroring `--path`/`--config` validation.

### Changes

- `src/directoryOverrides.ts` — new pure helpers (`parseDirectoryOverrides`, `getDirectoryKey`, `mergeOverride`).
- `src/index.ts` — load overrides from the config, pass merged `ExtraData` to `buildReadme` per directory in `emitSubReadmes`.
- `test/directoryOverrides.test.js` — 19 new tests covering unit helpers and end-to-end scenarios via `main([...])`.
- `awesome-readme.config.js` — commented `directories` example.
- `README.md` — new "Per-directory overrides" section in the config docs.
- `examples/with-overrides/` — runnable demo with overrides for `src`, `src/hooks`, and `.vscode`.
- `package.json` — bumped to `0.2.0` (SemVer minor: additive, opt-in).

### Verification

```
npm ci
npm run lint
npm run format:check
npm run typecheck
npm run build
npm test
```

All 96 tests pass (77 existing + 19 new). End-to-end smoke against the new example was confirmed by hand; the project's own READMEs (root, examples, src, test, .vscode) were regenerated to match the new template.