### PR TITLE
docs+ci: add CHANGELOG, release process, and tag-driven npm publish

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,10 +5,17 @@ request... were there any bugs you had fixed? If so, mention them. If
 these bugs have open GitHub issues, be sure to tag them here as well,
 to keep the conversation linked together. -->
 
+### Checklist
+
+- [ ] `npm run lint`, `npm run format:check`, `npm run typecheck`,
+      `npm run build`, and `npm test` all pass locally.
+- [ ] User-facing changes are documented in `README.md` and/or
+      `CHANGELOG.md` (under `[Unreleased]`).
+
 ### Other Information
 
-<!-- If there's anything else that's important and relevant to your pull
-request, mention that information here. This could include
+<!-- If there's anything else that's important and relevant to your
+pull request, mention that information here. This could include
 benchmarks, or other information.
 
 Thanks for contributing! -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  verify:
+    name: Verify on Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20', '22', '24']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+  publish:
+    name: Publish to npm
+    needs: verify
+    runs-on: ubuntu-latest
+    # Only run on the tag that triggered the workflow, never on branch pushes.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      id-token: write # required for npm trusted publishing (provenance)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # `prepublishOnly` in package.json already runs the build, but running it
+      # explicitly here makes the workflow log self-contained.
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          # NODE_AUTH_TOKEN is set automatically by setup-node from the
+          # trusted publisher configuration, but the secret is also accepted
+          # as a fallback for repositories that have not configured it yet.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2026-07-28
+
+### Added
+
+- Per-directory config overrides via a top-level `directories` block in
+  `awesome-readme.config.js`. Keys are project-root-relative POSIX paths;
+  matching is exact (no cascade), so an override for `src` does not apply
+  to `src/internal`. The walker and ignore rules stay global so the tree
+  stays consistent across READMEs.
+- Recursive directory walk to arbitrary depth, backed by a single shared
+  recursion so root and subdirectory READMEs agree on which entries to
+  visit.
+- Preserve hand-written README content across regenerations. Generated
+  content now lives between `<!-- awesome-readme:start -->` and
+  `<!-- awesome-readme:end -->` markers; only that region is rewritten
+  on subsequent runs. A README without markers is left untouched unless
+  `--force` is passed.
+- Auto-generate the figlet banner from `package.json` `name` via the
+  new `figlet_auto` option (defaults to `true` when neither `figlet`
+  nor `figlet_text` is set).
+- Render the banner from a `figlet_text` string via the `figlet`
+  package, with `figlet_font` for picking a font.
+- Glob patterns and sensible defaults in `ignore_files`. A small set of
+  defaults (`node_modules/`, `dist/`, `coverage/`, `build/`) is merged
+  in automatically; set `ignore_defaults: false` to opt out.
+- CLI flags: `--help`, `--dry-run`, `--path`, `--config`, `--root-only`,
+  `--force`, `--if-missing`.
+- Checked-in example projects under `examples/` demonstrating the
+  common usage patterns.
+
+### Changed
+
+- CI runs on a Node 20 / 22 / 24 matrix and `engines.node` is aligned to
+  `>=20`.
+- `npm test` runs the suite on every supported Node version rather
+  than only on the CI host.
+- Lint covers the real sources; type errors are gated in CI via
+  `npm run typecheck`.
+- Package metadata cleaned up: the unused `fs` runtime dependency is
+  dropped, the broken `browser` field is removed, and `engines.node` is
+  bumped.
+- `.gitignore` parsing now uses real gitignore semantics (via the
+  `ignore` package).
+- The root and subdirectory READMEs share one tree renderer so the
+  rendered output is consistent.
+
+### Fixed
+
+- Stop publishing TypeScript sources to npm via `.npmignore`.
+- Derive the license badge from `package.json` repository metadata.
+- Apply `ignore_files` (and the gitignore-derived rules) when generating
+  subdirectory READMEs, not only the root one.
+- Subdirectory tree connectors: nested entries now render under their
+  parent directory instead of being flattened into the root.
+
+### Dependencies
+
+- Added `ignore` as a runtime dependency (updated to v7).
+
+## [0.1.0] - 2025-XX-XX
+
+Initial TypeScript rewrite with `sub_license`, `sub_header`, `sub_body`,
+and `sub_footer` config options for per-directory READMEs, plus a fix
+for nested subdirectory tree rendering.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,18 @@ will fix most lint and formatting complaints for you.
 > `npm run typecheck` instead. When typescript-eslint gains TS >=7.1 support, the
 > ignore entry in `eslint.config.js` should be removed.
 
-3. Document the new features, or functionality in README.md
+3. Document the new features or behavior changes:
 
-4. Increase the version numbers in package.json to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+   - Update [`README.md`](./README.md) if the change affects how users
+     install, configure, or run the tool.
+   - Add a bullet to the `[Unreleased]` section of
+     [`CHANGELOG.md`](./CHANGELOG.md) so it lands in the next release
+     notes. Group entries under `Added`, `Changed`, `Fixed`, `Removed`,
+     and `Dependencies`, in that order.
+
+Version bumps and npm publishing happen at release time, not per PR. The
+release process is documented in [`RELEASING.md`](./RELEASING.md); the
+versioning scheme is [SemVer](http://semver.org/).
 
 ## Code of Conduct
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,103 @@
+# Releasing
+
+This document describes how to cut a release of `awesome-readme`. For day-to-day
+contribution instructions, see [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+
+- **MAJOR** for incompatible API or behavior changes (config option removals,
+  output-format breaking changes, Node.js major bumps).
+- **MINOR** for new features in a backward-compatible way (new config options,
+  new CLI flags, new examples).
+- **PATCH** for backward-compatible bug fixes and dependency bumps.
+
+Anything tagged `@internal`, `@experimental`, or hidden behind a feature flag is
+fair game for breaking changes within a minor.
+
+## Release process
+
+Releases are fully driven by Git tags. The workflow lives in
+[`.github/workflows/release.yml`](./.github/workflows/release.yml) and runs on
+any tag matching `v*.*.*`. There is no release branch.
+
+### 1. Land the changes
+
+Open a PR (or a series of PRs) that introduces the changes you want to ship.
+Each PR must leave `main` green: lint, format check, typecheck, build, and test
+all run on the Node 20 / 22 / 24 matrix in CI.
+
+### 2. Update the CHANGELOG
+
+Add an entry to the `[Unreleased]` section of [`CHANGELOG.md`](./CHANGELOG.md)
+that summarizes the user-visible changes for the upcoming release. Group them
+under `Added`, `Changed`, `Fixed`, `Removed`, and `Dependencies`, in that order.
+Keep entries short and link to the PR or issue when relevant.
+
+### 3. Bump the version
+
+In `package.json`, set `version` to the new semver string. Open a PR titled
+`chore: bump version to <X.Y.Z>` that contains only this one-line change plus
+the CHANGELOG move in step 4. Wait for it to merge before tagging.
+
+### 4. Move the Unreleased entry into a dated section
+
+In `CHANGELOG.md`:
+
+1. Rename the `[Unreleased]` section to `[X.Y.Z] - YYYY-MM-DD`, where the date
+   is the day you are tagging (UTC).
+2. Add a fresh, empty `[Unreleased]` section above it.
+3. Add the comparison links at the bottom of the file for the new release and
+   the previous `Unreleased` placeholder (see the existing file for the format).
+
+Open this in the same version-bump PR as step 3.
+
+### 5. Tag the release
+
+From a clean `main`:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git tag -s vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+The `-s` flag signs the tag with your GPG/SSH key, which npm uses to verify
+provenance. If you have not configured signing yet, omit `-s`; provenance will
+still work via the workflow's OIDC token, but signed tags are preferred.
+
+Pushing the tag triggers `.github/workflows/release.yml`, which:
+
+- Runs the full CI matrix (lint, format check, typecheck, build, test) on
+  Node 20 / 22 / 24.
+- Runs `npm publish --provenance --access public` on Node 24 if every check
+  passes.
+
+### 6. Verify
+
+After the workflow completes:
+
+- Confirm the new version on
+  [npm](https://www.npmjs.com/package/awesome-readme).
+- Confirm the GitHub release page lists the tag (creating it from the tag UI
+  is optional; the workflow does not do it automatically to keep the action
+  surface small).
+- Confirm the `Unreleased` link in `CHANGELOG.md` and `README.md` still
+  resolve.
+
+## Publishing authentication
+
+The release workflow uses [npm trusted publishing](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions)
+(OIDC) for `--provenance`. Configure it once per npm package:
+
+1. On npmjs.com, go to **Package settings → Publishing access → Trusted
+   publishers** and add a trusted publisher for this repository with the
+   workflow filename `.github/workflows/release.yml` and the environment name
+   `npm` (optional but recommended).
+
+If trusted publishing is not yet configured, set a fallback `NPM_TOKEN` secret
+on the repository (Settings → Secrets and variables → Actions) and the workflow
+will pick it up automatically. Rotate the token if a maintainer leaves the
+team.


### PR DESCRIPTION
Closes #94.

## Summary

- Add `CHANGELOG.md` (Keep a Changelog format) seeded with the 0.2.0
  release notes — the actual 0.2.0 commit shipped without one.
- Add `RELEASING.md` documenting the SemVer policy, the tag-driven
  release flow, and npm trusted publishing.
- Update `CONTRIBUTING.md` so contributors add a bullet under
  `[Unreleased]` in CHANGELOG.md rather than bumping versions per PR.
- Update the PR template with a checklist for local CI commands and
  the CHANGELOG entry.
- Add `.github/workflows/release.yml`: on any `v*.*.*` tag, re-run
  the full lint/format/typecheck/build/test matrix on Node 20/22/24,
  then publish with `--provenance` on Node 24.

## Why

Issue #94 calls out that the package is at 0.2.0 with no CHANGELOG
and no automated release/publish workflow. Consumers and contributors
have no history of changes, and publishing is currently a manual
`npm publish` that is easy to get wrong (wrong version, missing
build, no provenance, dirty working tree).

## Changes

### `CHANGELOG.md` (new)
- `[Unreleased]` placeholder.
- `[0.2.0]` section with `Added`, `Changed`, `Fixed`, and
  `Dependencies` groups derived from the commits between 0.1.0
  (`a92241b`) and 0.2.0 (`559a6fd`).
- Brief `[0.1.0]` stub for the prior cycle.

### `RELEASING.md` (new)
- Versioning policy (SemVer, with examples of what counts as major /
  minor / patch).
- Six-step release process: land → update CHANGELOG → bump version →
  move `[Unreleased]` into a dated section → tag → verify.
- Notes on GPG/SSH signed tags and how provenance works.
- Section on npm trusted publishing (OIDC) and the `NPM_TOKEN`
  fallback.

### `.github/workflows/release.yml` (new)
- Trigger: `push` of tags matching `v*.*.*`.
- `verify` job: lint, format check, typecheck, build, and `npm test`
  on the Node 20 / 22 / 24 matrix (`fail-fast: false`).
- `publish` job (`needs: verify`): runs on Node 24 with
  `id-token: write` for npm trusted publishing; falls back to the
  `NPM_TOKEN` secret when trusted publishing is not configured.
- Only publishes when `github.event_name == 'push'` and the ref
  starts with `refs/tags/v`, so re-running the verify job on a
  branch can never accidentally publish.

### `CONTRIBUTING.md` (modified)
- Step 3 now asks contributors to update README.md and add a bullet
  under `[Unreleased]` in CHANGELOG.md.
- Old step 4 (bump version in PR) replaced with a pointer to
  RELEASING.md, since releases happen at tag time.

### `.github/pull_request_template.md` (modified)
- Adds a Checklist section for the local CI commands and the
  CHANGELOG entry.

## Verification

Locally on the branch:

- `npm run lint` — clean
- `npm run format:check` — clean
- `npm run typecheck` — clean
- `npm test` — 96/96 pass

The release workflow YAML was parsed with `js-yaml` to catch syntax
errors before pushing. The publish job will be exercised by pushing
a `v0.2.1-rc.0` test tag after this PR merges (see RELEASING.md).