### PR TITLE
chore(renovate): narrow automerge to patch-level devDependency bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,7 +20,9 @@
       "addLabels": ["optional"]
     },
     {
-      "matchDepTypes": ["minor", "patch", "devDependencies"],
+      "description": "Automerge only patch-level bumps of devDependencies. Minor bumps (and runtime deps) still need a human eye until tests + typecheck cover more behavior. See issue #97.",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch"],
       "automerge": true,
       "automergeType": "pr"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Renovate now only automerges patch-level bumps of `devDependencies`.
+  The previous rule mixed update types into `matchDepTypes`, which made
+  it effectively allow every devDep bump of every severity; minor and
+  major toolchain bumps now open a normal PR for review instead of
+  landing silently. The policy is documented in `CONTRIBUTING.md`.
+
 ## [0.2.0] - 2026-07-28
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,26 @@ Version bumps and npm publishing happen at release time, not per PR. The
 release process is documented in [`RELEASING.md`](./RELEASING.md); the
 versioning scheme is [SemVer](http://semver.org/).
 
+## Renovate policy
+
+Renovate runs on this repo with a deliberately narrow automerge scope. The
+active rule in [`.github/renovate.json`](./.github/renovate.json) is:
+
+- **`devDependencies` at `patch` only** are automerged.
+- Everything else — minor/major bumps, runtime `dependencies`, and any
+  peer/optional bumps — opens a normal PR for review.
+
+The rule used to read `matchDepTypes: ["minor", "patch", "devDependencies"]`,
+which mixed invalid values into the array (`minor` and `patch` are update
+types, not dependency types) and effectively let every devDep bump of every
+severity through. Even with the test + typecheck matrix now gating CI, we
+keep automerge tight on purpose: toolchain majors (e.g. ESLint, TypeScript)
+have historically broken the project, and a noisy auto-merge queue is worse
+than a small one.
+
+Reopen the scope if/when the test suite grows to cover generation
+end-to-end and a release process exists to roll back bad bumps.
+
 ## Code of Conduct
 
 ### Our Pledge


### PR DESCRIPTION
Closes #97

## What

The previous Renovate rule read:

```json
{ "matchDepTypes": ["minor", "patch", "devDependencies"], "automerge": true }
```

That mixes update types into `matchDepTypes`, which only accepts
dependency types — so `"minor"` and `"patch"` were silently ignored
and the rule effectively let every devDep bump of every severity
(minor, major, anything) land without review. Combined with the
missing test/typecheck coverage at the time, that was risky.

Replace it with an explicit pair:

```json
{
  "description": "Automerge only patch-level bumps of devDependencies. ...",
  "matchDepTypes": ["devDependencies"],
  "matchUpdateTypes": ["patch"],
  "automerge": true,
  "automergeType": "pr"
}
```

So:

- patch bumps of devDependencies → still automerged
- minor/major bumps, runtime deps, peer/optional bumps → normal PR for
  review (no automerge)

## Why

Issue #97. Even with the test + typecheck matrix now gating CI, the
scoped policy is the safer default — toolchain majors (ESLint,
TypeScript) have historically broken the project, and a noisy
auto-merge queue is worse than a small one. Documented the policy in
`CONTRIBUTING.md` so future maintainers can reopen the scope
intentionally.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm test` (96/96 pass)

## Notes

Adds an `[Unreleased]` entry to `CHANGELOG.md` per the
contribution guide.