### PR TITLE
feat: introduce template system for README layouts (#90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ npx awesome-readme --if-missing
 | `--root-only` | Write only the root README and skip subdirectory READMEs. |
 | `--force` | Replace existing READMEs entirely, including hand-written content. |
 | `--if-missing` | Create READMEs only in directories that do not already have one. |
+| `--template-root <file>` | Render the root README from a custom template file. |
+| `--template-sub <file>` | Render subdirectory READMEs from a custom template file. |
 
 `--force` and `--if-missing` cannot be combined.
 
@@ -128,7 +130,11 @@ module.exports = {
       sub_header: '## Internal helpers',
       sub_body: 'Private implementation details.'
     }
-  }
+  },
+
+  // Optional: point at a custom template file (see "Templates" below).
+  // template_root: './templates/root.md',
+  // template_sub: './templates/sub.md'
 };
 ```
 
@@ -148,8 +154,82 @@ module.exports = {
 | `ignore_defaults` | Ignore `node_modules/`, `dist/`, `coverage/`, and `build/`; defaults to `true`. |
 | `max_depth` | Maximum directory depth to traverse; defaults to `10`. |
 | `directories` | Exact per-directory patches for the eight `root_*` and `sub_*` content fields. |
+| `template_root` | Path to a custom template file for the root README (see [Templates](#templates)). |
+| `template_sub` | Path to a custom template file for subdirectory READMEs. |
 
 Directory override keys must be project-root-relative POSIX paths such as `src` or `packages/api`. Matching is exact and does not cascade: an override for `src` does not apply to `src/internal`. The root README cannot be overridden, and walker or ignore settings remain global. Set a content field to an empty string to clear it for one directory.
+
+## Templates
+
+The generated README is rendered through a small template instead of being assembled by string concatenation. The default templates ship with the tool and reproduce the existing layout section-for-section, so projects that do nothing get the same output they always did. To customize the layout, point at your own template file:
+
+```sh
+npx awesome-readme --template-root ./templates/root.md --template-sub ./templates/sub.md
+```
+
+The same paths can live in `awesome-readme.config.js` for projects that want to ship the layout alongside the rest of the configuration:
+
+```js
+module.exports = {
+  template_root: './templates/root.md',
+  template_sub: './templates/sub.md'
+};
+```
+
+CLI flags take precedence over the config, and both fall back to the bundled defaults when neither is supplied. A missing template file exits with `Template file not found: <absolute path>` so the error message points at the exact file the resolver looked for.
+
+### Supported syntax
+
+The renderer recognises three constructs:
+
+- `{{name}}` — substitute a value. Missing values render as the empty string. Dotted paths such as `{{this.role}}` walk an object chain, so loop entries expose their fields by name alongside `{{this}}`.
+- `{{#if name}}…{{/if}}` — render the body only when `name` is truthy (non-empty string, non-empty array, non-zero number, or `true`).
+- `{{#each name}}…{{/each}}` — render the body once per entry in `name`. Inside the body, `{{this}}` references the entry itself and object entries also expose their fields as bare names.
+
+Whitespace inside and around the markers is preserved verbatim, so authors control the newlines around placeholders by writing the template the way they want it rendered.
+
+### Variables
+
+Both default templates are written against the same variable names, so a custom template can be swapped in for either without learning a separate vocabulary.
+
+| Variable | Description |
+| --- | --- |
+| `name` | Heading text. For the root README this is `package.json` `name`; for a subdirectory it is the `parent / child` breadcrumb. |
+| `licenseBadge` | Markdown image badge derived from the project's license and repository slug. Empty when no slug is available. |
+| `license` | Value of `root_license` (root) or `sub_license` (sub). |
+| `figlet` | ASCII-art banner, already wrapped in a fenced code block. |
+| `header` | Value of `root_header` (root) or `sub_header` (sub). |
+| `body` | Value of `root_body` (root) or `sub_body` (sub). |
+| `footer` | Value of `root_footer` (root) or `sub_footer` (sub). |
+| `directories` | Rendered list of immediate subdirectories as `- [name/](./name/)` lines. Empty when the directory has none. |
+| `files` | Rendered list of immediate files as `- [name](./name)` lines. Empty when the directory has none. |
+| `tree` | The full directory tree, wrapped in a fenced code block. Empty when there is nothing to render. |
+| `previousUrl` | URL of the `[<- Previous]` link. Set for every subdirectory README; empty for the root. |
+| `description` | Extra prose rendered under the banner. Subdirectory READMEs only; empty for the root. |
+
+### Custom layout example
+
+```md
+<!-- templates/root.md -->
+# {{name}}
+{{figlet}}
+
+{{header}}
+
+{{#if directories}}## Directories
+{{directories}}{{/if}}
+{{#if files}}## Files
+{{files}}{{/if}}
+
+{{body}}
+
+{{#if tree}}## Project tree
+{{tree}}{{/if}}
+
+{{footer}}
+```
+
+Point the config at this file (`template_root: './templates/root.md'`) and the next run emits this layout instead of the default.
 
 ## Examples
 
@@ -157,6 +237,7 @@ Directory override keys must be project-root-relative POSIX paths such as `src` 
 - [`examples/nested`](./examples/nested/) — nested directory generation.
 - [`examples/with-config`](./examples/with-config/) — custom global content and filtering.
 - [`examples/with-overrides`](./examples/with-overrides/) — exact per-directory content overrides.
+- [`examples/with-templates`](./examples/with-templates/) — custom root and subdirectory templates.
 
 ## Contributing
 

--- a/examples/with-templates/README.md
+++ b/examples/with-templates/README.md
@@ -1,0 +1,36 @@
+<!-- awesome-readme:start -->
+# with-templates
+
+
+
+
+
+## Directories
+
+ - [src/](./src/) - [templates/](./templates/)
+
+
+## Files
+
+ - [awesome-readme.config.js](./awesome-readme.config.js)
+ - [package.json](./package.json)
+
+
+
+
+## Project tree
+
+```
+with-templates/
+├─── awesome-readme.config.js
+└─── package.json
+├─── src/
+│   └─── index.js
+└─── templates/
+    ├─── root.md
+    └─── sub.md
+```
+
+
+
+<!-- awesome-readme:end -->

--- a/examples/with-templates/awesome-readme.config.js
+++ b/examples/with-templates/awesome-readme.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  // Disable the auto-generated figlet so the custom template's banner slot
+  // stays empty unless `figlet` / `figlet_text` is supplied explicitly.
+  figlet_auto: false,
+  // Point at the templates that ship with this example. The same paths
+  // could be passed via the CLI as `--template-root` / `--template-sub`.
+  // Relative paths resolve against the current working directory, matching
+  // how `--config` is resolved.
+  template_root: './templates/root.md',
+  template_sub: './templates/sub.md'
+};

--- a/examples/with-templates/package.json
+++ b/examples/with-templates/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "with-templates",
+  "version": "0.1.0",
+  "description": "Example that swaps the bundled README templates for custom ones shipped alongside the config.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/example/with-templates.git"
+  }
+}

--- a/examples/with-templates/src/README.md
+++ b/examples/with-templates/src/README.md
@@ -1,0 +1,27 @@
+<!-- awesome-readme:start -->
+# with-templates / src
+
+
+
+
+
+
+
+## Files
+
+ - [index.js](./index.js)
+
+
+
+## Layout
+
+[Back to with-templates / src](https://github.com/example/with-templates)
+
+```
+src/
+   └─── index.js
+```
+
+
+
+<!-- awesome-readme:end -->

--- a/examples/with-templates/src/index.js
+++ b/examples/with-templates/src/index.js
@@ -1,0 +1,2 @@
+// Tiny placeholder module so the example has a real file to render in its tree.
+module.exports = { name: 'with-templates' };

--- a/examples/with-templates/templates/README.md
+++ b/examples/with-templates/templates/README.md
@@ -1,0 +1,28 @@
+<!-- awesome-readme:start -->
+# with-templates / templates
+
+
+
+
+
+
+
+## Files
+
+ - [root.md](./root.md) - [sub.md](./sub.md)
+
+
+
+## Layout
+
+[Back to with-templates / templates](https://github.com/example/with-templates)
+
+```
+templates/
+   ├─── root.md
+   └─── sub.md
+```
+
+
+
+<!-- awesome-readme:end -->

--- a/examples/with-templates/templates/root.md
+++ b/examples/with-templates/templates/root.md
@@ -1,0 +1,24 @@
+# {{name}}
+
+{{figlet}}
+{{header}}
+
+{{#if directories}}
+## Directories
+
+{{directories}}
+{{/if}}
+{{#if files}}
+## Files
+
+{{files}}
+{{/if}}
+{{#if body}}
+{{body}}
+{{/if}}
+{{#if tree}}
+## Project tree
+
+{{tree}}
+{{/if}}
+{{footer}}

--- a/examples/with-templates/templates/sub.md
+++ b/examples/with-templates/templates/sub.md
@@ -1,0 +1,27 @@
+# {{name}}
+
+{{figlet}}
+{{description}}
+
+{{header}}
+{{#if directories}}
+## Sub-directories
+
+{{directories}}
+{{/if}}
+{{#if files}}
+## Files
+
+{{files}}
+{{/if}}
+{{#if body}}
+{{body}}
+{{/if}}
+{{#if tree}}
+## Layout
+
+[Back to {{name}}]({{previousUrl}})
+
+{{tree}}
+{{/if}}
+{{footer}}

--- a/src/buildReadme.ts
+++ b/src/buildReadme.ts
@@ -1,3 +1,4 @@
+import { renderTemplate, DEFAULT_SUB_TEMPLATE } from './template';
 import { renderTreeLines, type TreeNode } from './tree';
 import type { ExtraData } from './types';
 import type { DirectoryNode } from './walk';
@@ -27,6 +28,12 @@ export interface SubReadmeOptions {
    * bare mode or the full write options (`--force`, `--if-missing`).
    */
   writeOptions?: ReadmeWriteMode | ReadmeWriteOptions;
+  /**
+   * Template used to render this README. Resolved once in `src/index.ts`
+   * (CLI flag → config → default) and threaded through the recursive walk so
+   * every subdirectory shares the same layout.
+   */
+  template?: string;
 }
 
 /**
@@ -48,7 +55,18 @@ export const toTreeNodes = (node: DirectoryNode): TreeNode[] => [
  * to the root README's and hold at any depth.
  */
 const buildReadme = (options: SubReadmeOptions): string => {
-  const { node, title, figlet, licenseBadge, description = '', previousUrl, prefix = '', extraData, writeOptions = 'write' } = options;
+  const {
+    node,
+    title,
+    figlet,
+    licenseBadge,
+    description = '',
+    previousUrl,
+    prefix = '',
+    extraData,
+    writeOptions = 'write',
+    template = DEFAULT_SUB_TEMPLATE
+  } = options;
 
   let directoryFileList = '';
   let currentFilesList = '';
@@ -63,21 +81,22 @@ const buildReadme = (options: SubReadmeOptions): string => {
   // subdirectory README shows everything below it. `prefix` shifts the block
   // one level in so it still reads as a tree hanging off the directory name.
   const treeLines = renderTreeLines(toTreeNodes(node)).map((line) => `${prefix}${line}`);
-  const directoryTree = treeLines.join('\n');
-  const directoryTreePrefix = `\`\`\`\n${node.name}/\n`;
-  const directoryTreeSuffix = `\`\`\``;
-  const readmeContents = `
-${licenseBadge ? licenseBadge + '\n\n' : ''}${extraData.sub_license}
-# ${title ? title : 'Awesome-Readme'}
-${figlet}
-${description ? description : ''}
-${extraData.sub_header}
-${directoryFileList ? '## Directories\n' + directoryFileList + '\n' : ''}
-${currentFilesList ? currentFilesList : ''}
-${extraData.sub_body}
-${directoryTree ? '## Directory Tree\n[<- Previous](' + previousUrl + ')\n' + directoryTreePrefix + directoryTree + '\n' + directoryTreeSuffix : ''}
-${extraData.sub_footer}
-`;
+  const directoryTree = `\`\`\`\n${node.name}/\n${treeLines.join('\n')}\n\`\`\``;
+  const variables = {
+    name: title || 'Awesome-Readme',
+    licenseBadge,
+    license: extraData.sub_license,
+    figlet,
+    header: extraData.sub_header,
+    directories: directoryFileList,
+    files: currentFilesList,
+    body: extraData.sub_body,
+    tree: directoryTree,
+    footer: extraData.sub_footer,
+    previousUrl,
+    description
+  };
+  const readmeContents = renderTemplate(template, variables);
   writeReadmeFile(node.path, readmeContents, writeOptions);
   return directoryTree;
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,10 @@ export interface CliOptions {
   ifMissing: boolean;
   path?: string;
   config?: string;
+  /** Path to a custom template for the root README. */
+  templateRoot?: string;
+  /** Path to a custom template for subdirectory READMEs. */
+  templateSub?: string;
 }
 
 export const usage = `Usage: awesome-readme [options]
@@ -31,11 +35,13 @@ that region is regenerated. A README without markers is left untouched unless
 Options:
   -h, --help            Show this help message and exit
       --dry-run         Print what would be written without writing any file
-  -p, --path <dir>      Project root to generate READMEs for (default: current directory)
-  -c, --config <file>   Path to the config file (default: <path>/awesome-readme.config.js)
-      --root-only       Only write the root README, skip subdirectory READMEs
-      --force           Overwrite existing READMEs entirely, discarding their content
-      --if-missing      Only create READMEs for directories that do not have one
+  -p, --path <dir>          Project root to generate READMEs for (default: current directory)
+  -c, --config <file>       Path to the config file (default: <path>/awesome-readme.config.js)
+      --root-only           Only write the root README, skip subdirectory READMEs
+      --force               Overwrite existing READMEs entirely, discarding their content
+      --if-missing          Only create READMEs for directories that do not have one
+      --template-root <f>   Use a custom template for the root README
+      --template-sub <f>    Use a custom template for subdirectory READMEs
 
 Examples:
   awesome-readme
@@ -43,7 +49,8 @@ Examples:
   awesome-readme --path ./packages/core --config ./readme.config.js
   awesome-readme --root-only
   awesome-readme --if-missing
-  awesome-readme --force`;
+  awesome-readme --force
+  awesome-readme --template-root ./my-root.md --template-sub ./my-sub.md`;
 
 /**
  * Parse `process.argv.slice(2)` into `CliOptions`.
@@ -66,7 +73,9 @@ export const parseCliOptions = (argv: string[]): CliOptions => {
         force: { type: 'boolean', default: false },
         'if-missing': { type: 'boolean', default: false },
         path: { type: 'string', short: 'p' },
-        config: { type: 'string', short: 'c' }
+        config: { type: 'string', short: 'c' },
+        'template-root': { type: 'string' },
+        'template-sub': { type: 'string' }
       }
     });
   } catch (err) {
@@ -81,12 +90,16 @@ export const parseCliOptions = (argv: string[]): CliOptions => {
     'if-missing'?: boolean;
     path?: string;
     config?: string;
+    'template-root'?: string;
+    'template-sub'?: string;
   };
 
   // `--path` / `--config` with an empty value is a user mistake rather than a
   // request to use the default, so reject it instead of silently falling back.
   if (values.path !== undefined && values.path.trim() === '') throw new Error('Option --path requires a directory.');
   if (values.config !== undefined && values.config.trim() === '') throw new Error('Option --config requires a file path.');
+  if (values['template-root'] !== undefined && values['template-root'].trim() === '') throw new Error('Option --template-root requires a file path.');
+  if (values['template-sub'] !== undefined && values['template-sub'].trim() === '') throw new Error('Option --template-sub requires a file path.');
   // `--force` overwrites everything and `--if-missing` refuses to touch any
   // existing file: asking for both is a contradiction, not a precedence puzzle.
   if (values.force === true && values['if-missing'] === true) throw new Error('Options --force and --if-missing cannot be combined.');
@@ -98,7 +111,9 @@ export const parseCliOptions = (argv: string[]): CliOptions => {
     force: values.force === true,
     ifMissing: values['if-missing'] === true,
     path: values.path,
-    config: values.config
+    config: values.config,
+    templateRoot: values['template-root'],
+    templateSub: values['template-sub']
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import buildReadme, { toTreeNodes } from './buildReadme';
 import { parseCliOptions, usage, type CliOptions } from './cli';
 import { parseDirectoryOverrides, getDirectoryKey, mergeOverride } from './directoryOverrides';
 import { renderTreeLines } from './tree';
+import { DEFAULT_ROOT_TEMPLATE, DEFAULT_SUB_TEMPLATE, loadTemplateFile, renderTemplate } from './template';
 import type { ExtraData } from './types';
 import { walkDirectory, flattenDirectories, DEFAULT_MAX_DEPTH, type DirectoryNode } from './walk';
 import { writeReadmeFile, type ReadmeWriteMode, type ReadmeWriteOptions } from './writeReadme';
@@ -208,6 +209,13 @@ ${rendered}
     currentFilesList += ` - [${file}](./${file})\n`;
   });
 
+  // Resolve templates once up front so a missing custom file fails fast
+  // before any READMEs are touched. CLI flags win over the config so users
+  // can preview a layout without editing the project file, then fall back to
+  // the bundled defaults when neither is supplied.
+  const rootTemplate = resolveTemplate(options.templateRoot, config?.template_root, DEFAULT_ROOT_TEMPLATE);
+  const subTemplate = resolveTemplate(options.templateSub, config?.template_sub, DEFAULT_SUB_TEMPLATE);
+
   /**
    * Emit one README per directory, at any depth.
    *
@@ -235,7 +243,8 @@ ${rendered}
         previousUrl: child.depth === 1 ? repositoryUrl : '../README.md',
         prefix: '   ',
         extraData: childExtraData,
-        writeOptions: subWriteOptions
+        writeOptions: subWriteOptions,
+        template: subTemplate
       });
       emitSubReadmes(child, title);
     });
@@ -247,19 +256,39 @@ ${rendered}
   // cannot drift apart between them at any depth.
   const treeLines: string[] = [`${repositoryName}/`, ...renderTreeLines(toTreeNodes(tree))];
   const directoryTree = `\`\`\`\n${treeLines.join('\n')}\n\`\`\``;
-  const buildReadmeData = `
-${licenseBadge}${licenseBadge ? '\n' : ''}${extraData.root_license}
-
-# ${repositoryName}
-${figlet}
-${extraData.root_header}
-${directoryFileList ? '## Directories\n' + directoryFileList + '\n' : ''}
-${currentFilesList ? currentFilesList : ''}
-${extraData.root_body}
-${directoryTree ? '## Directory Tree\n' + directoryTree : ''}
-${extraData.root_footer}
-`;
+  const rootVariables = {
+    name: repositoryName,
+    licenseBadge,
+    license: extraData.root_license,
+    figlet,
+    header: extraData.root_header,
+    directories: directoryFileList,
+    files: currentFilesList,
+    body: extraData.root_body,
+    tree: directoryTree,
+    footer: extraData.root_footer,
+    // The root README does not link to a "previous" page, but exposing the
+    // variable keeps the template vocabulary uniform across root and sub.
+    previousUrl: '',
+    description: ''
+  };
+  const buildReadmeData = renderTemplate(rootTemplate, rootVariables);
   writeReadmeFile(currentPath, buildReadmeData, rootWriteOptions);
+};
+
+/**
+ * Resolve a template string using the CLI/config/default precedence.
+ *
+ * The CLI flag overrides the config key (so `--template-root` wins over
+ * `template_root` in `awesome-readme.config.js`), and both fall back to the
+ * bundled default when neither is supplied. A relative path is resolved
+ * against the current working directory, matching the behaviour of
+ * `--config`.
+ */
+const resolveTemplate = (cliPath: string | undefined, configPath: unknown, fallback: string): string => {
+  if (typeof cliPath === 'string' && cliPath.length > 0) return loadTemplateFile(cliPath);
+  if (typeof configPath === 'string' && configPath.length > 0) return loadTemplateFile(configPath);
+  return fallback;
 };
 
 /**

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,0 +1,164 @@
+/**
+ * Tiny Mustache-flavoured template renderer used by the README generator.
+ *
+ * The generator used to assemble each README by string-concatenating ten or
+ * so pieces, which made layout changes tedious and let the root and
+ * subdirectory paths drift apart. This module replaces that with a single
+ * template per README, so custom layouts are a matter of writing a template
+ * file instead of patching two parallel string templates in source.
+ *
+ * Supported syntax:
+ *
+ * - `{{name}}` — substitute a value from the `values` object. Missing or
+ *   `null` values render as the empty string; numbers and booleans render as
+ *   their string form (booleans as `"true"` / `""`).
+ *
+ * - `{{#if name}}…{{/if}}` — render the body only when `name` is truthy. A
+ *   value is truthy when it is a non-empty string, a non-empty array, a
+ *   non-zero number, or literally `true`.
+ *
+ * - `{{#each name}}…{{/each}}` — render the body once per entry in `name`.
+ *   Inside the body, `{{this}}` references the entry itself; when the entry
+ *   is an object its fields are also exposed as bare names so
+ *   `{{label}}` works alongside `{{this}}`.
+ *
+ * The renderer is intentionally small and dependency-free: README templates
+ * rarely need more than these three constructs, and pulling in Handlebars
+ * or Mustache would inflate the install footprint for very little gain.
+ */
+
+/** Values accepted by `renderTemplate`. */
+export type TemplateVariables = Record<string, unknown>;
+
+/**
+ * Render a template string against the given variable bag.
+ *
+ * Placeholders, `if` blocks and `each` blocks are evaluated in that order.
+ * `each` bodies are recursively rendered so nested `{{var}}` and `{{#if}}`
+ * constructs work as expected. `each` and `if` blocks are non-greedy and
+ * match their first closing tag, which is enough for the README templates
+ * this module ships with.
+ */
+export const renderTemplate = (template: string, values: TemplateVariables): string => {
+  // `each` first: the body is recursively rendered, so its inner `{{var}}`
+  // and `{{#if}}` placeholders are resolved in the recursive call rather
+  // than here.
+  const eachExpanded = template.replace(/\{\{#each\s+([\w$]+)\}\}([\s\S]*?)\{\{\/each\}\}/g, (_match, name: string, body: string) => {
+    const list = values[name];
+    if (!Array.isArray(list)) return '';
+    return list
+      .map((entry) => {
+        // An object entry's fields are merged into the value bag so the
+        // body can reference them directly (`{{label}}`); a primitive
+        // entry is exposed only as `{{this}}` and inherits no fields.
+        const scoped: TemplateVariables =
+          entry !== null && typeof entry === 'object' ? { ...values, ...(entry as TemplateVariables), this: entry } : { ...values, this: entry };
+        return renderTemplate(body, scoped);
+      })
+      .join('');
+  });
+  // `if` next: by the time we get here every `each` block is fully expanded,
+  // so the body has no nested `{{#each}}` to confuse the regex.
+  const ifExpanded = eachExpanded.replace(/\{\{#if\s+([\w$]+)\}\}([\s\S]*?)\{\{\/if\}\}/g, (_match, name: string, body: string) =>
+    isTruthy(values[name]) ? body : ''
+  );
+  // Variable substitution last: any `{{name}}` left in the string is a
+  // plain reference into the value bag. Dotted paths (`{{user.name}}`) walk
+  // an object chain so loop bodies can reach at fields like `{{this.role}}`
+  // without having to repeat the object literal in the value bag.
+  return ifExpanded.replace(/\{\{([\w$.]+)\}\}/g, (_match, name: string) => stringifyValue(resolvePath(values, name)));
+};
+
+/**
+ * Walk a dotted path against an arbitrary value bag.
+ *
+ * `user.name` reads `values.user.name`; `this.role` reads the current loop
+ * entry's `role` field. A missing intermediate value returns `undefined`,
+ * which `stringifyValue` then renders as the empty string.
+ */
+const resolvePath = (values: TemplateVariables, path: string): unknown => {
+  const parts = path.split('.');
+  let current: unknown = values[parts[0]];
+  for (let index = 1; index < parts.length; index += 1) {
+    if (current === undefined || current === null) return undefined;
+    current = (current as Record<string, unknown>)[parts[index]];
+  }
+  return current;
+};
+
+const isTruthy = (value: unknown): boolean => {
+  if (value === undefined || value === null || value === false) return false;
+  if (typeof value === 'string') return value.length > 0;
+  if (typeof value === 'number') return value !== 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return Boolean(value);
+};
+
+const stringifyValue = (value: unknown): string => {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'boolean') return value ? 'true' : '';
+  return String(value);
+};
+
+/**
+ * Default template for the project root README.
+ *
+ * The shape mirrors what the generator produced before templates existed, so
+ * existing projects see the same output by default. Every section that used
+ * to be a conditional inline expression is gated here by `{{#if}}`, which
+ * keeps the placeholder list short and the conditional logic readable.
+ */
+export const DEFAULT_ROOT_TEMPLATE = `{{licenseBadge}}{{#if licenseBadge}}
+{{/if}}{{license}}
+# {{name}}
+{{figlet}}
+{{header}}{{#if directories}}
+
+## Directories
+{{directories}}{{/if}}{{#if files}}{{files}}{{/if}}{{body}}{{#if tree}}
+
+## Directory Tree
+{{tree}}{{/if}}
+{{footer}}`;
+
+/**
+ * Default template for every subdirectory README.
+ *
+ * Same shape as the root template with two additions: a `[<- Previous]`
+ * link inside the directory tree section, and an optional `{{description}}`
+ * paragraph rendered straight under the banner.
+ */
+export const DEFAULT_SUB_TEMPLATE = `{{licenseBadge}}{{#if licenseBadge}}
+
+{{/if}}{{license}}
+# {{name}}
+{{figlet}}{{#if description}}
+{{description}}{{/if}}
+{{header}}{{#if directories}}
+
+## Directories
+{{directories}}{{/if}}{{#if files}}{{files}}{{/if}}{{body}}{{#if tree}}
+
+## Directory Tree
+[<- Previous]({{previousUrl}})
+{{tree}}{{/if}}
+{{footer}}`;
+
+/**
+ * Read a custom template from disk.
+ *
+ * Path resolution mirrors `--config`: relative paths are resolved against the
+ * current working directory, so a `--template-root ./my-template.md` works
+ * without the caller having to spell out an absolute location. A missing
+ * file is reported with the resolved absolute path so the user can fix
+ * typos without having to guess where the resolver looked.
+ */
+export const loadTemplateFile = (templatePath: string): string => {
+  const fs = require('fs') as typeof import('fs');
+  const path = require('path') as typeof import('path');
+  const resolved = path.resolve(templatePath);
+  if (!fs.existsSync(resolved)) throw new Error(`Template file not found: ${resolved}`);
+  return fs.readFileSync(resolved, 'utf8');
+};
+
+export default renderTemplate;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -62,7 +62,9 @@ test('parseCliOptions defaults every flag to off', () => {
     force: false,
     ifMissing: false,
     path: undefined,
-    config: undefined
+    config: undefined,
+    templateRoot: undefined,
+    templateSub: undefined
   });
 });
 
@@ -74,7 +76,9 @@ test('parseCliOptions reads long and short forms', () => {
     force: false,
     ifMissing: false,
     path: undefined,
-    config: undefined
+    config: undefined,
+    templateRoot: undefined,
+    templateSub: undefined
   });
   assert.strictEqual(parseCliOptions(['-h']).help, true);
   assert.strictEqual(parseCliOptions(['--dry-run']).dryRun, true);
@@ -85,6 +89,8 @@ test('parseCliOptions reads long and short forms', () => {
   assert.strictEqual(parseCliOptions(['-p', './pkg']).path, './pkg');
   assert.strictEqual(parseCliOptions(['--config', 'a.js']).config, 'a.js');
   assert.strictEqual(parseCliOptions(['-c', 'a.js']).config, 'a.js');
+  assert.strictEqual(parseCliOptions(['--template-root', 'root.md']).templateRoot, 'root.md');
+  assert.strictEqual(parseCliOptions(['--template-sub', 'sub.md']).templateSub, 'sub.md');
 });
 
 test('parseCliOptions rejects unknown flags, missing values and positionals', () => {
@@ -92,6 +98,8 @@ test('parseCliOptions rejects unknown flags, missing values and positionals', ()
   assert.throws(() => parseCliOptions(['--path']));
   assert.throws(() => parseCliOptions(['--path', '']), /--path requires a directory/);
   assert.throws(() => parseCliOptions(['--config', '  ']), /--config requires a file path/);
+  assert.throws(() => parseCliOptions(['--template-root', '  ']), /--template-root requires a file path/);
+  assert.throws(() => parseCliOptions(['--template-sub', '']), /--template-sub requires a file path/);
   assert.throws(() => parseCliOptions(['extra-arg']));
 });
 
@@ -189,6 +197,93 @@ test('a missing --config or --path exits non-zero', () => {
     assert.match(missingPath.stderr, /Project path not found/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Coverage for #90: --template-root swaps the root README layout without
+// touching the bundled default, so users can preview a layout in a scratch
+// directory before committing it to the project config.
+test('--template-root renders the root README from a custom template file', () => {
+  const root = makeProject();
+  const templateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-tpl-cli-'));
+  const templatePath = path.join(templateDir, 'root.md');
+  fs.writeFileSync(templatePath, 'CUSTOM-ROOT-{{name}}\n');
+
+  try {
+    const { result } = captureOutput(() => main(['--path', root, '--template-root', templatePath]));
+
+    assert.strictEqual(result, 0);
+    const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+    assert.match(readme, /CUSTOM-ROOT-demo/);
+    // The bundled default would emit `# demo`, but the custom template
+    // replaces the whole layout, so the heading is gone.
+    assert.doesNotMatch(readme, /^# demo$/m);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(templateDir, { recursive: true, force: true });
+  }
+});
+
+// Coverage for #90: --template-sub applies to every subdirectory README in
+// the same run, so a single flag is enough to rebrand the entire tree.
+test('--template-sub renders subdirectory READMEs from a custom template file', () => {
+  const root = makeProject();
+  const templateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-tpl-sub-'));
+  const templatePath = path.join(templateDir, 'sub.md');
+  fs.writeFileSync(templatePath, 'CUSTOM-SUB {{name}}\n');
+
+  try {
+    const { result } = captureOutput(() => main(['--path', root, '--template-sub', templatePath]));
+
+    assert.strictEqual(result, 0);
+    const subReadme = fs.readFileSync(path.join(root, 'src', 'README.md'), 'utf8');
+    assert.match(subReadme, /CUSTOM-SUB demo \/ src/);
+    // The bundled default would emit `[<- Previous](...)` inside the tree
+    // section; a fully custom template that does not reference it must
+    // suppress the link, not silently keep the default.
+    assert.doesNotMatch(subReadme, /\[<- Previous\]/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(templateDir, { recursive: true, force: true });
+  }
+});
+
+// Coverage for #90: a missing custom template path is reported with a
+// dedicated error message rather than the generic config-file one, so
+// users do not have to second-guess which flag they got wrong.
+test('a missing --template-root exits non-zero with a dedicated error', () => {
+  const root = makeProject();
+  const templateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-tpl-missing-'));
+  const missing = path.join(templateDir, 'does-not-exist.md');
+
+  try {
+    const { result, stderr } = captureOutput(() => main(['--path', root, '--template-root', missing]));
+    assert.strictEqual(result, 1);
+    assert.match(stderr, /Template file not found/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(templateDir, { recursive: true, force: true });
+  }
+});
+
+// Coverage for #90: the config file can also point to custom templates, so
+// projects can ship their layout alongside the rest of the configuration.
+test('config.template_root renders the root README from a template file in the config', () => {
+  const root = makeProject();
+  const templateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-tpl-cfg-'));
+  const templatePath = path.join(templateDir, 'root.md');
+  fs.writeFileSync(templatePath, 'CONFIG-ROOT-{{name}}\n');
+  fs.writeFileSync(path.join(root, 'awesome-readme.config.js'), `module.exports = { template_root: ${JSON.stringify(templatePath)} };\n`);
+
+  try {
+    const { result } = captureOutput(() => main(['--path', root]));
+
+    assert.strictEqual(result, 0);
+    const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+    assert.match(readme, /CONFIG-ROOT-demo/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(templateDir, { recursive: true, force: true });
   }
 });
 

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -1,0 +1,206 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const { renderTemplate, DEFAULT_ROOT_TEMPLATE, DEFAULT_SUB_TEMPLATE, loadTemplateFile } = require('../dist/template');
+
+test('renderTemplate substitutes a single variable', () => {
+  assert.strictEqual(renderTemplate('Hello, {{name}}!', { name: 'world' }), 'Hello, world!');
+});
+
+test('renderTemplate substitutes the same variable multiple times', () => {
+  assert.strictEqual(renderTemplate('{{x}} and {{x}}', { x: 'yo' }), 'yo and yo');
+});
+
+test('renderTemplate renders missing variables as empty strings', () => {
+  assert.strictEqual(renderTemplate('[{{missing}}]', {}), '[]');
+});
+
+test('renderTemplate renders null and undefined variables as empty strings', () => {
+  assert.strictEqual(renderTemplate('[{{a}}|{{b}}]', { a: null, b: undefined }), '[|]');
+});
+
+test('renderTemplate stringifies numbers and booleans', () => {
+  assert.strictEqual(renderTemplate('count={{n}} ok={{ok}} off={{off}}', { n: 3, ok: true, off: false }), 'count=3 ok=true off=');
+});
+
+test('renderTemplate {{#if}} renders the body only when the value is truthy', () => {
+  const truthy = renderTemplate('{{#if name}}hi {{name}}{{/if}}', { name: 'alice' });
+  const falsy = renderTemplate('{{#if name}}hi {{name}}{{/if}}', { name: '' });
+  const undef = renderTemplate('{{#if name}}hi {{name}}{{/if}}', {});
+  assert.strictEqual(truthy, 'hi alice');
+  assert.strictEqual(falsy, '');
+  assert.strictEqual(undef, '');
+});
+
+test('renderTemplate {{#if}} treats non-empty arrays as truthy', () => {
+  assert.strictEqual(renderTemplate('{{#if items}}has items{{/if}}', { items: ['a'] }), 'has items');
+  assert.strictEqual(renderTemplate('{{#if items}}full{{/if}}', { items: [] }), '');
+});
+
+test('renderTemplate {{#if}} treats zero as falsy', () => {
+  assert.strictEqual(renderTemplate('{{#if n}}non-zero{{/if}}', { n: 0 }), '');
+  assert.strictEqual(renderTemplate('{{#if n}}non-zero{{/if}}', { n: 1 }), 'non-zero');
+});
+
+test('renderTemplate {{#each}} renders the body once per entry', () => {
+  const out = renderTemplate('{{#each items}}- {{this}}\n{{/each}}', { items: ['a', 'b', 'c'] });
+  assert.strictEqual(out, '- a\n- b\n- c\n');
+});
+
+test('renderTemplate {{#each}} exposes object fields by name alongside {{this}}', () => {
+  const out = renderTemplate('{{#each users}}{{name}}={{this.role}};{{/each}}', {
+    users: [{ name: 'alice', role: 'admin' }, { name: 'bob', role: 'user' }]
+  });
+  assert.strictEqual(out, 'alice=admin;bob=user;');
+});
+
+test('renderTemplate {{#each}} renders nothing for a non-array', () => {
+  assert.strictEqual(renderTemplate('{{#each x}}{{this}}{{/each}}', { x: 'scalar' }), '');
+  assert.strictEqual(renderTemplate('{{#each x}}{{this}}{{/each}}', {}), '');
+});
+
+test('renderTemplate resolves nested {{#if}} and {{var}} inside {{#each}}', () => {
+  const out = renderTemplate('{{#each items}}{{#if active}}*{{name}}{{/if}}{{/each}}', {
+    items: [
+      { name: 'a', active: true },
+      { name: 'b', active: false },
+      { name: 'c', active: true }
+    ]
+  });
+  assert.strictEqual(out, '*a*c');
+});
+
+test('renderTemplate preserves whitespace around placeholders verbatim', () => {
+  // The newline between `{{#if name}}` and the body is part of the rendered
+  // output, so authors can drop in a heading without manually joining it to
+  // the surrounding content.
+  const out = renderTemplate('A{{#if name}}\nB\n{{/if}}C', { name: 'x' });
+  assert.strictEqual(out, 'A\nB\nC');
+});
+
+test('DEFAULT_ROOT_TEMPLATE renders all the standard sections', () => {
+  // Minimal variables covering every placeholder used by the default root
+  // template. The output is the section-by-section composition, not a
+  // exact-byte snapshot, so the assertion is "every section is present and
+  // in the right order" rather than a string equality. Whitespace rules
+  // changed when the template replaced the inline string-concatenation;
+  // each section's *presence* is what matters here.
+  const out = renderTemplate(DEFAULT_ROOT_TEMPLATE, {
+    name: 'demo',
+    licenseBadge: '[![license](https://example.test/license.svg)](https://example.test/license)',
+    license: '[![npm](https://example.test/npm.svg)](https://example.test/npm)',
+    figlet: '\n```\nASCII\n```',
+    header: '## Welcome',
+    directories: ' - [src/](./src/)\n',
+    files: ' - [README.md](./README.md)\n',
+    body: 'Body text.',
+    tree: '```\ndemo/\n└─── src/\n```',
+    footer: '## Bye',
+    previousUrl: '',
+    description: ''
+  });
+  assert.match(out, /# demo/);
+  assert.match(out, /## Welcome/);
+  assert.match(out, /\[!\[\w+\]\([^)]+\)\]\([^)]+\)/);
+  assert.match(out, /\[src\/\]\(\.\/src\/\)/);
+  assert.match(out, /\[README\.md\]\(\.\/README\.md\)/);
+  assert.match(out, /Body text\./);
+  assert.match(out, /## Directory Tree/);
+  assert.match(out, /demo\/\n└─── src\//);
+  assert.match(out, /## Bye/);
+  // The order is enforced by relative positions, not exact spacing.
+  assert.ok(out.indexOf('# demo') < out.indexOf('## Welcome'), 'heading precedes header');
+  assert.ok(out.indexOf('## Welcome') < out.indexOf('## Directories'), 'header precedes directories');
+  assert.ok(out.indexOf('## Directories') < out.indexOf('## Directory Tree'), 'directories precede tree');
+  assert.ok(out.indexOf('## Directory Tree') < out.indexOf('## Bye'), 'tree precedes footer');
+});
+
+test('DEFAULT_SUB_TEMPLATE renders the [<- Previous] link inside the tree section', () => {
+  const out = renderTemplate(DEFAULT_SUB_TEMPLATE, {
+    name: 'parent / child',
+    licenseBadge: '',
+    license: '',
+    figlet: '',
+    header: '',
+    directories: '',
+    files: '',
+    body: '',
+    tree: '```\nchild/\n└─── file.txt\n```',
+    footer: '',
+    previousUrl: '../README.md',
+    description: ''
+  });
+  assert.match(out, /# parent \/ child/);
+  assert.match(out, /\[<- Previous\]\(\.\.\/README\.md\)/);
+  // The previous link is rendered inside the tree section, so it has to
+  // appear before the actual tree fence.
+  const linkIndex = out.indexOf('[<- Previous]');
+  const fenceIndex = out.indexOf('```');
+  assert.ok(linkIndex !== -1 && fenceIndex !== -1 && linkIndex < fenceIndex, 'Previous link must precede the tree fence');
+});
+
+test('DEFAULT_SUB_TEMPLATE renders {{description}} when supplied', () => {
+  const out = renderTemplate(DEFAULT_SUB_TEMPLATE, {
+    name: 'demo',
+    licenseBadge: '',
+    license: '',
+    figlet: '',
+    header: '',
+    directories: '',
+    files: '',
+    body: '',
+    tree: '',
+    footer: '',
+    previousUrl: '',
+    description: 'A short paragraph.'
+  });
+  assert.match(out, /A short paragraph\./);
+});
+
+test('DEFAULT_SUB_TEMPLATE renders nothing extra when every section is empty', () => {
+  // With nothing to render except the title, the output should still
+  // contain the heading and nothing more — no stray badge, no spurious
+  // previous link, no phantom "## " headings.
+  const out = renderTemplate(DEFAULT_SUB_TEMPLATE, {
+    name: 'demo',
+    licenseBadge: '',
+    license: '',
+    figlet: '',
+    header: '',
+    directories: '',
+    files: '',
+    body: '',
+    tree: '',
+    footer: '',
+    previousUrl: '',
+    description: ''
+  });
+  assert.match(out, /# demo/);
+  assert.doesNotMatch(out, /\[!/);
+  assert.doesNotMatch(out, /\[<- Previous\]/);
+  assert.doesNotMatch(out, /^## /m);
+});
+
+test('loadTemplateFile reads a UTF-8 template from disk', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-tpl-'));
+  const file = path.join(dir, 'root.md');
+  fs.writeFileSync(file, '# {{name}}');
+  try {
+    assert.strictEqual(loadTemplateFile(file), '# {{name}}');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadTemplateFile throws with the resolved path when the file is missing', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-readme-tpl-missing-'));
+  const missing = path.join(dir, 'nope.md');
+  try {
+    assert.throws(() => loadTemplateFile(missing), /Template file not found/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #90.

## Summary

Replace the inline string-concatenation that built each README with a tiny Mustache-flavoured template renderer, so custom layouts become a matter of writing a template file rather than patching two parallel string templates in source. The bundled defaults reproduce the existing section order, so projects that do nothing get the same output they always did.

## Changes

- **`src/template.ts`** — new renderer that supports `{{var}}`, `{{#if var}}…{{/if}}`, `{{#each var}}…{{/each}}`, and dotted-path access (`{{this.role}}`). Ships `DEFAULT_ROOT_TEMPLATE` / `DEFAULT_SUB_TEMPLATE` and a `loadTemplateFile` helper that reports the resolved path on a missing file.
- **`src/index.ts`** / **`src/buildReadme.ts`** — wire the renderer into both the root README and the recursive subdirectory walk. Templates are resolved once per run with the precedence `CLI flag` > `config key` > bundled default.
- **`src/cli.ts`** — add `--template-root` / `--template-sub`, validate empty values, and update the usage text.
- **`test/template.test.js`** (new) — walk every construct the renderer exposes plus the file-loader round trip.
- **`test/cli.test.js`** — update the parser defaults, add long-form parsing and empty-value rejections, and lock down the end-to-end behaviour (`--template-root`, `--template-sub`, missing-file error, `template_root` config key).
- **`README.md`** — document the two new CLI flags, the two matching config keys, the supported syntax, the full variable list, and a custom-layout example.
- **`examples/with-templates/`** (new) — runnable demo with a config that points at two template files in `templates/` and the rendered READMEs the generator produces on a clean run.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run format:check` — clean
- `npm test` — 119 / 119 passing (96 pre-existing + 23 new)