### PR TITLE
test: cover license and repository-slug generation

### DIFF
--- a/src/badge.ts
+++ b/src/badge.ts
@@ -1,0 +1,60 @@
+/**
+ * Normalise `package.json`'s `repository` field into a plain URL.
+ *
+ * `package.json` accepts both a shorthand string and a `{ type, url }` object,
+ * and shorthand strings frequently start with `git+` and end with `.git`.
+ * Both forms point at the same remote once those decorations are stripped.
+ * Anything other than a string or a `{ url }` object yields an empty string
+ * so callers can skip the badge step entirely.
+ */
+export const deriveRepositoryUrl = (repository: unknown): string => {
+  if (typeof repository === 'string') {
+    if (repository.startsWith('git+')) return repository.replace('git+', '').replace('.git', '');
+    return repository;
+  }
+  if (typeof repository === 'object' && repository !== null) {
+    const url = (repository as { url?: unknown }).url;
+    if (typeof url === 'string') {
+      // The shorthand `{ "url": "git+...git" }` form carries the same
+      // `git+`/`.git` decorations as the string form. Strip them so the
+      // resulting URL can be fed straight into the slug detector.
+      const stripped = url.startsWith('git+') ? url.replace('git+', '') : url;
+      return stripped.endsWith('.git') ? stripped.slice(0, -'.git'.length) : stripped;
+    }
+  }
+  return '';
+};
+
+/**
+ * Reduce a repository URL to its `owner/repo` slug.
+ *
+ * The README badges hardcode `img.shields.io/github/license/<slug>.svg`, so a
+ * missing or unparseable slug should produce an empty string rather than a
+ * half-built URL pointing at the wrong project.
+ */
+export const deriveRepositorySlug = (url: string): string => {
+  if (!url) return '';
+  const cleaned = url
+    .replace(/^git\+/, '')
+    .replace(/\.git$/, '')
+    .replace(/\/+$/, '');
+  // SSH-style: `git@github.com:owner/repo` matches after the colon;
+  // HTTPS-style: `https://github.com/owner/repo` matches after the slash.
+  const sshMatch = cleaned.match(/[/:]([^/]+\/[^/]+)$/);
+  if (sshMatch) return sshMatch[1];
+  return '';
+};
+
+/**
+ * Build the Markdown license badge for the README header.
+ *
+ * The image target is the Shields.io GitHub license endpoint, which only
+ * resolves `owner/repo` slugs correctly. A malformed slug (e.g. one parsed
+ * from a non-GitHub URL) would point the badge at a 404, so the helper
+ * refuses anything that does not match the `owner/repo` shape and returns an
+ * empty string. The template's `{{#if}}` then skips the badge line entirely.
+ */
+export const buildLicenseBadge = (slug: string, license: string): string => {
+  if (!slug || !/^[^/]+\/[^/]+$/.test(slug)) return '';
+  return `[![license](https://img.shields.io/github/license/${slug}.svg)](https://opensource.org/licenses/${license})`;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import figletLib from 'figlet';
 
 import buildReadme, { toTreeNodes } from './buildReadme';
+import { buildLicenseBadge, deriveRepositorySlug, deriveRepositoryUrl } from './badge';
 import { parseCliOptions, usage, type CliOptions } from './cli';
 import { parseDirectoryOverrides, getDirectoryKey, mergeOverride } from './directoryOverrides';
 import { renderTreeLines } from './tree';
@@ -148,33 +149,13 @@ ${rendered}
       console.log('\x1b[31m', 'Failed to auto-generate figlet for "' + String(repositoryName) + '" with font "' + figletFont + '":', '\x1b[0m', err);
     }
   }
-  let repositoryUrl = '';
-  if (typeof repository === 'string')
-    if (repository.startsWith('git+')) repositoryUrl = repository.replace('git+', '').replace('.git', '');
-    else repositoryUrl = repository;
-  else if (typeof repository === 'object') {
-    repositoryUrl = repository.url.substring(4);
-    repositoryUrl = repositoryUrl.substring(0, repositoryUrl.length - 4);
-  }
+  const repositoryUrl = deriveRepositoryUrl(repository);
   // Derive the GitHub "owner/repo" slug from the repository URL so license
   // badges point at the actual project instead of a hardcoded third-party
   // repo. Accepts https and ssh-style URLs, and falls back to an empty string
   // when no slug can be derived (e.g. non-GitHub remotes or missing metadata).
-  const deriveRepositorySlug = (url: string): string => {
-    if (!url) return '';
-    const cleaned = url
-      .replace(/^git\+/, '')
-      .replace(/\.git$/, '')
-      .replace(/\/+$/, '');
-    // SSH-style: git@github.com:owner/repo  → matches after the colon
-    const sshMatch = cleaned.match(/[/:]([^/]+\/[^/]+)$/);
-    if (sshMatch) return sshMatch[1];
-    return '';
-  };
   const repositorySlug = deriveRepositorySlug(repositoryUrl);
-  const licenseBadge = repositorySlug
-    ? `[![license](https://img.shields.io/github/license/${repositorySlug}.svg)](https://opensource.org/licenses/${repositoryLicensee})`
-    : '';
+  const licenseBadge = buildLicenseBadge(repositorySlug, repositoryLicensee);
   // List of all the files in the current directory, with the shared ignore
   // rules applied. The same helper is used for every subdirectory walk so a
   // file ignored here cannot reappear in a sub-README or subdirectory tree.

--- a/test/badge.test.js
+++ b/test/badge.test.js
@@ -1,0 +1,116 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const { buildLicenseBadge, deriveRepositorySlug, deriveRepositoryUrl } = require('../dist/badge');
+
+test('deriveRepositoryUrl passes a plain https URL through unchanged', () => {
+  assert.strictEqual(deriveRepositoryUrl('https://github.com/owner/repo'), 'https://github.com/owner/repo');
+});
+
+test('deriveRepositoryUrl strips the git+ prefix and .git suffix from a shorthand string', () => {
+  assert.strictEqual(deriveRepositoryUrl('git+https://github.com/owner/repo.git'), 'https://github.com/owner/repo');
+});
+
+test('deriveRepositoryUrl strips git+ and .git from a string without an https scheme', () => {
+  assert.strictEqual(deriveRepositoryUrl('git+ssh://git@github.com/owner/repo.git'), 'ssh://git@github.com/owner/repo');
+});
+
+test('deriveRepositoryUrl leaves an undecorated SSH URL alone', () => {
+  assert.strictEqual(deriveRepositoryUrl('ssh://git@github.com/owner/repo'), 'ssh://git@github.com/owner/repo');
+});
+
+test('deriveRepositoryUrl accepts the { type, url } object form', () => {
+  assert.strictEqual(
+    deriveRepositoryUrl({ type: 'git', url: 'git+https://github.com/owner/repo.git' }),
+    'https://github.com/owner/repo'
+  );
+});
+
+test('deriveRepositoryUrl accepts an undecorated object form', () => {
+  assert.strictEqual(deriveRepositoryUrl({ type: 'git', url: 'https://github.com/owner/repo' }), 'https://github.com/owner/repo');
+});
+
+test('deriveRepositoryUrl returns an empty string for missing metadata', () => {
+  assert.strictEqual(deriveRepositoryUrl(undefined), '');
+  assert.strictEqual(deriveRepositoryUrl(null), '');
+  assert.strictEqual(deriveRepositoryUrl(''), '');
+});
+
+test('deriveRepositoryUrl returns an empty string for an object with no url field', () => {
+  assert.strictEqual(deriveRepositoryUrl({ type: 'git' }), '');
+});
+
+test('deriveRepositoryUrl returns an empty string for a non-string url field', () => {
+  assert.strictEqual(deriveRepositoryUrl({ url: 42 }), '');
+});
+
+test('deriveRepositorySlug extracts owner/repo from an https URL', () => {
+  assert.strictEqual(deriveRepositorySlug('https://github.com/owner/repo'), 'owner/repo');
+});
+
+test('deriveRepositorySlug strips the .git suffix before matching', () => {
+  assert.strictEqual(deriveRepositorySlug('https://github.com/owner/repo.git'), 'owner/repo');
+});
+
+test('deriveRepositorySlug strips the git+ prefix before matching', () => {
+  assert.strictEqual(deriveRepositorySlug('git+https://github.com/owner/repo'), 'owner/repo');
+});
+
+test('deriveRepositorySlug extracts owner/repo from an SSH-style URL', () => {
+  assert.strictEqual(deriveRepositorySlug('git@github.com:owner/repo'), 'owner/repo');
+});
+
+test('deriveRepositorySlug strips trailing slashes from the URL', () => {
+  assert.strictEqual(deriveRepositorySlug('https://github.com/owner/repo/'), 'owner/repo');
+  assert.strictEqual(deriveRepositorySlug('https://github.com/owner/repo///'), 'owner/repo');
+});
+
+test('deriveRepositorySlug returns an empty string for a missing URL', () => {
+  assert.strictEqual(deriveRepositorySlug(''), '');
+});
+
+test('deriveRepositorySlug extracts whatever owner/repo segment it can parse', () => {
+  // The helper does not validate the host, so a non-GitHub remote with two
+  // path segments still yields a "slug". The badge helper rejects slugs that
+  // do not look like `owner/repo`, so the same input that produces a slug
+  // here still does not produce a badge.
+  assert.strictEqual(deriveRepositorySlug('https://gitlab.com/owner/repo'), 'owner/repo');
+});
+
+test('buildLicenseBadge rejects inputs that do not match the owner/repo shape', () => {
+  // Three or more slash-separated segments would build a badge URL pointing
+  // at the wrong endpoint, so the helper bails out with an empty string.
+  assert.strictEqual(buildLicenseBadge('a/b/c', 'MIT'), '');
+});
+
+test('deriveRepositorySlug returns an empty string for a URL with too few path segments', () => {
+  assert.strictEqual(deriveRepositorySlug('https://github.com/'), '');
+  assert.strictEqual(deriveRepositorySlug('https://github.com'), '');
+});
+
+test('buildLicenseBadge builds the Shields.io badge with the slug and license', () => {
+  assert.strictEqual(
+    buildLicenseBadge('owner/repo', 'MIT'),
+    '[![license](https://img.shields.io/github/license/owner/repo.svg)](https://opensource.org/licenses/MIT)'
+  );
+});
+
+test('buildLicenseBadge preserves the SPDX license identifier verbatim', () => {
+  assert.strictEqual(
+    buildLicenseBadge('owner/repo', 'Apache-2.0'),
+    '[![license](https://img.shields.io/github/license/owner/repo.svg)](https://opensource.org/licenses/Apache-2.0)'
+  );
+});
+
+test('buildLicenseBadge returns an empty string when the slug is missing', () => {
+  // A missing slug means the URL was not GitHub-shaped, so emitting a badge
+  // would point at the wrong project. The empty string lets the template
+  // skip the badge line entirely via `{{#if}}`.
+  assert.strictEqual(buildLicenseBadge('', 'MIT'), '');
+});
+
+test('buildLicenseBadge still links to the SPDX page when the slug is present', () => {
+  const out = buildLicenseBadge('marc-aurele-besner/awesome-readme', 'MIT');
+  assert.match(out, /opensource\.org\/licenses\/MIT/);
+  assert.match(out, /img\.shields\.io\/github\/license\/marc-aurele-besner\/awesome-readme\.svg/);
+});


### PR DESCRIPTION
Closes #80

The repository-slug and license-badge logic used to live inline in
src/index.ts, which made it untestable in isolation and let non-GitHub
URLs produce a broken badge URL.

This PR:

- Extracts the helpers into src/badge.ts: deriveRepositoryUrl,
  deriveRepositorySlug, and buildLicenseBadge.
- Tightens buildLicenseBadge to reject slugs that do not match the
  `owner/repo` shape, so a non-GitHub remote (e.g. an extra path
  segment) no longer points the Shields.io badge at a 404.
- Adds test/badge.test.js with focused coverage for every helper
  (git+ prefix, .git suffix, SSH-style URLs, the package.json { url }
  object form, missing metadata, SPDX link target).