### PR TITLE
chore: drop deprecated jsxBracketSameLine from .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,6 +5,5 @@
   "semi": true,
   "singleQuote": true,
   "trailingComma": "none",
-  "bracketSpacing": true,
-  "jsxBracketSameLine": true
+  "bracketSpacing": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   major toolchain bumps now open a normal PR for review instead of
   landing silently. The policy is documented in `CONTRIBUTING.md`.
 
+### Fixed
+
+- Dropped the deprecated `jsxBracketSameLine` option from `.prettierrc`.
+  The repo contains no JSX or TSX, so the flag had no effect; removing it
+  silences the `[warn] jsxBracketSameLine is deprecated.` notice that
+  appeared on every `npm run format:check` invocation.
+
 ## [0.2.0] - 2026-07-28
 
 ### Added


### PR DESCRIPTION
### Summary
Remove the deprecated `jsxBracketSameLine` flag from `.prettierrc`. Prettier prints `[warn] jsxBracketSameLine is deprecated.` on every `npm run format:check` run, but the option only affects JSX/TSX files and the repo contains none, so it has been dead config.

### Why
- Silences a deprecation warning that pollutes every CI `Check formatting` step.
- Drops config with no effect on actual sources.

### Changes
- `.prettierrc`: remove `"jsxBracketSameLine": true`.
- `CHANGELOG.md`: add a `Fixed` bullet under `[Unreleased]`.

### Verification
All CI checks pass locally on this branch:
- `npm run format:check` → no deprecation warning, all files use Prettier style.
- `npm run lint` → clean.
- `npm run typecheck` → clean.
- `npm run build` → clean.
- `npm test` → 141 passing.