### PR TITLE
ci: run node --test directly so the Test step does not rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Run `node --test` directly (not `npm test`) so we don't rebuild:
+      # `npm test` is `npm run build && node --test`, and the Build step above
+      # already produced `dist/`. Rebuilding here would just double the work and
+      # obscure whether a failure came from the build or from the tests.
       - name: Test
-        run: npm test
+        run: node --test


### PR DESCRIPTION
## Summary

The CI workflow's `Test` step ran `npm test`, which is `npm run build && node --test`. Because the `Build` step right above it already produced `dist/`, the test step was rebuilding the project a second time on every matrix run (Node 20, 22, 24). Replace the test command with `node --test` so the tests run against the already-built artifacts instead of rebuilding.

## Why

- Saves a `tsc` invocation per matrix shard — CI was doing 2 × 3 = 6 builds per run where 3 would do.
- Makes the failure surface unambiguous: a `Build` step failure is a build failure, a `Test` step failure is a test failure. Today a regression in `tsc` would surface as a failing test step.

## Behavior

`dist/` is still guaranteed to be fresh before tests run because the `Build` step executes immediately before. Locally, `npm test` keeps its current contract (build + test in one command for devs) — only the CI invocation changes.

Verified locally on this branch:

```
$ npm run lint          # ok
$ npm run format:check  # ok
$ npm run typecheck     # ok
$ npm run build         # ok
$ node --test           # 141 pass, 0 fail
```

## Closes

Closes #95 — the typecheck and test steps were already in CI; this just removes the redundant rebuild inside the test step and leaves the original acceptance criteria satisfied.

## Notes

- The smoke test at `examples/nested/test/smoke.test.js` is still discovered (141 tests, same as before) because `node --test` with no arguments walks the repo root and picks up any `test/**/*.js`.